### PR TITLE
Pull all the gems: server command

### DIFF
--- a/.rubocop-bundler.yml
+++ b/.rubocop-bundler.yml
@@ -47,7 +47,9 @@ Style/StringLiteralsInInterpolation:
 
 # Having these make it easier to *not* forget to add one when adding a new
 # value and you can simply copy the previous line.
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
 # 1.8.7 support
@@ -67,7 +69,9 @@ Style/EachWithObject:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+Style/TrailingCommaInArguments:
   Enabled: false
 
 # Metrics

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -40,14 +40,14 @@ Table of Contents
     * [Version](#version)
       * [Usage](#usage-5)
     * [Preload](#preload)
-      * [Usage](#usage-5)
+      * [Usage](#usage-6)
       * [Options](#options-5)
         * [--latest](#--latest)
         * [--prerelease](#--prerelease)
         * [--skip](#--skip)
         * [--limit](#--limit)
         * [--threads](#--threads)
-        * [--server-url](#--server-url)
+        * [--upstream](#--upstream)
 
 
 
@@ -329,11 +329,10 @@ gemstash -v
 
 ## Preload
 
-Preload all the gems in your gemstash server from the default upstream.
-This can be useful if you plan to go somewhere where the internet connection
-will not be reliable or available.
-It is worth noting that this will require a large amount of disk space and
-computing time.
+Preload all the gems in your gemstash server from an upstream (defaults to the
+default gem source). This can be useful if you plan to go somewhere where the
+internet connection will not be reliable or available. It is worth noting that
+this will require a large amount of disk space and computing time.
 
 ### Usage
 
@@ -343,7 +342,7 @@ gemstash preload --latest
 gemstash preload --prerelease
 gemstash preload --limit=1000
 gemstash preload --limit=1000 --skip=1000
-gemstash preload --threads=10 --server-url=http://my-server-url:9292
+gemstash preload --threads=10 --upstream=https://my.gem-source.local
 ```
 
 ### Options
@@ -387,19 +386,17 @@ this can be used for loading gems in chunks or resuming the process.
 
 **Description**<br />
 Number of threads to run the fetching job with.
-Since this activity is heavily IO bound (most of the time goes into waiting the
+Since this activity is heavily IO bound (most of the time goes into waiting on the
 network) it is useful to use more threads for performing the task. The default
 number of threads is 20 already which should be good enough, but in case you
 want to experiment this value can be changed.
 
-#### --server-url
+#### --upstream
 
-**Usage:** `--server-url=<url>`
+**Usage:** `--upstream=<url>`
 
-**Description**<br />
-Gemstash server url. By default this is assumed to be running from the same
-host as the gemstash server so it will default to `http://localhost:9292` or
-whatever is defined in your configuration as the *bind* address.
+**Description**<br /> Upstream gem server url. By default this will be the
+default rubygems url ([which defaults to https://www.rubygems.org](#rubygems_url)).
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -322,7 +322,6 @@ Show what version of Gemstash you are using.
 ### Usage
 
 ```
-<<<<<<< HEAD
 gemstash version
 gemstash --version
 gemstash -v

--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -65,13 +65,14 @@ module Gemstash
     end
     map %w(-v --version) => :version
 
-    desc "preload", "Preloads all the gems in your gemstash server from the default upstream"
+    desc "preload", "Preloads all the gems from a single upstream"
     method_option :latest, type: :boolean, default: false, desc: "Only fetch the latest specs"
     method_option :prerelease, type: :boolean, default: false, desc: "Only fetch the prerelease specs"
-    method_option :server_url, type: :string, default: "http://localhost:9292", desc: "Gemstash server url"
+    method_option :upstream, type: :string, default: nil, desc: "Upstream to fetch from, else the default gem source"
     method_option :threads, type: :numeric, default: 20, desc: "Number of threads to run the fetching job with"
     method_option :limit, type: :numeric, default: nil, desc: "Limit for the number of gems to preload"
     method_option :skip, type: :numeric, default: 0, desc: "Number of gems to skip when preloading"
+    method_option :config_file, type: :string, desc: "Config file to load when preloading"
     def preload
       Gemstash::CLI::Preload.new(self).run
     end

--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -25,46 +25,36 @@ module Gemstash
     end
 
     desc "authorize [PERMISSIONS...]", "Add authorizations to push/yank/unyank private gems"
-    method_option :remove, :type => :boolean, :default => false, :desc =>
-      "Remove an authorization key"
-    method_option :config_file, :type => :string, :desc =>
-      "Config file to save to"
-    method_option :key, :type => :string, :desc =>
-      "Authorization key to create/update/delete (optional unless deleting)"
+    method_option :remove, type: :boolean, default: false, desc: "Remove an authorization key"
+    method_option :config_file, type: :string, desc: "Config file to save to"
+    method_option :key, type: :string, desc: "Authorization key to create/update/delete (optional unless deleting)"
     def authorize(*args)
       Gemstash::CLI::Authorize.new(self, *args).run
     end
 
     desc "setup", "Checks for dependencies and does initial setup"
-    method_option :redo, :type => :boolean, :default => false, :desc =>
-      "Redo configuration"
-    method_option :debug, :type => :boolean, :default => false, :desc =>
-      "Show detailed errors"
-    method_option :config_file, :type => :string, :desc =>
-      "Config file to save to"
+    method_option :redo, type: :boolean, default: false, desc: "Redo configuration"
+    method_option :debug, type: :boolean, default: false, desc: "Show detailed errors"
+    method_option :config_file, type: :string, desc: "Config file to save to"
     def setup
       Gemstash::CLI::Setup.new(self).run
     end
 
     desc "start", "Starts your gemstash server"
-    method_option :daemonize, :type => :boolean, :default => true, :desc =>
-      "Daemonize the server"
-    method_option :config_file, :type => :string, :desc =>
-      "Config file to load when starting"
+    method_option :daemonize, type: :boolean, default: true, desc: "Daemonize the server"
+    method_option :config_file, type: :string, desc: "Config file to load when starting"
     def start
       Gemstash::CLI::Start.new(self).run
     end
 
     desc "status", "Check the status of your gemstash server"
-    method_option :config_file, :type => :string, :desc =>
-      "Config file to load when checking the status"
+    method_option :config_file, type: :string, desc: "Config file to load when checking the status"
     def status
       Gemstash::CLI::Status.new(self).run
     end
 
     desc "stop", "Stops your gemstash server"
-    method_option :config_file, :type => :string, :desc =>
-      "Config file to load when stopping"
+    method_option :config_file, type: :string, desc: "Config file to load when stopping"
     def stop
       Gemstash::CLI::Stop.new(self).run
     end
@@ -76,18 +66,12 @@ module Gemstash
     map %w(-v --version) => :version
 
     desc "preload", "Preloads all the gems in your gemstash server from the default upstream"
-    method_option :latest, :type => :boolean, :default => false, :desc =>
-      "Only fetch the latest specs"
-    method_option :prerelease, :type => :boolean, :default => false, :desc =>
-      "Only fetch the prerelease specs"
-    method_option :server_url, :type => :string, :default => "http://localhost:9292", :desc =>
-      "Gemstash server url"
-    method_option :threads, :type => :numeric, :default => 20, :desc =>
-      "Number of threads to run the fetching job with"
-    method_option :limit, :type => :numeric, :default => nil, :desc =>
-      "Limit for the number of gems to preload"
-    method_option :skip, :type => :numeric, :default => 0, :desc =>
-      "Number of gems to skip when preloading"
+    method_option :latest, type: :boolean, default: false, desc: "Only fetch the latest specs"
+    method_option :prerelease, type: :boolean, default: false, desc: "Only fetch the prerelease specs"
+    method_option :server_url, type: :string, default: "http://localhost:9292", desc: "Gemstash server url"
+    method_option :threads, type: :numeric, default: 20, desc: "Number of threads to run the fetching job with"
+    method_option :limit, type: :numeric, default: nil, desc: "Limit for the number of gems to preload"
+    method_option :skip, type: :numeric, default: 0, desc: "Number of gems to skip when preloading"
     def preload
       Gemstash::CLI::Preload.new(self).run
     end

--- a/lib/gemstash/cli/preload.rb
+++ b/lib/gemstash/cli/preload.rb
@@ -4,18 +4,14 @@ module Gemstash
   class CLI
     # This implements the command line preload task to cache all the available gems:
     # $ gemstash preload
-    class Preload
-      include Gemstash::Env::Helper
-
-      def initialize(cli)
-        Gemstash::Env.current = Gemstash::Env.new
-        @cli = cli
-      end
-
+    class Preload < Gemstash::CLI::Base
       def run
+        prepare
         return unless are_you_sure?
-        http_client = HTTPClient.for(Upstream.new(@cli.options[:server_url]))
-        preloader = Gemstash::Preload::GemPreloader.new(http_client, @cli.options)
+        upstream_url = @cli.options[:upstream] || gemstash_env.config[:rubygems_url]
+        upstream = Gemstash::Upstream.new(upstream_url)
+        http_client = Gemstash::HTTPClient.for(upstream)
+        preloader = Gemstash::Preload::GemPreloader.new(upstream, http_client, @cli.options)
         preloader.preload
         @cli.say "\nDone"
       end

--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -94,10 +94,10 @@ module Gemstash
       def ask_database_details(database)
         say_current_config(:db_url, "Current database url")
 
-        if RUBY_PLATFORM == "java"
-          default_value = "jdbc:#{database}:///gemstash"
+        default_value = if RUBY_PLATFORM == "java"
+          "jdbc:#{database}:///gemstash"
         else
-          default_value = "#{database}:///gemstash"
+          "#{database}:///gemstash"
         end
 
         url = @cli.ask "Where is the database? [#{default_value}]"

--- a/lib/gemstash/db/cached_rubygem.rb
+++ b/lib/gemstash/db/cached_rubygem.rb
@@ -4,12 +4,12 @@ module Gemstash
   module DB
     # Sequel model for cached_rubygems table.
     class CachedRubygem < Sequel::Model
-      def self.store(upstream, gem_name, resource_type)
+      def self.store(gem_name)
         db.transaction do
-          upstream_id = Gemstash::DB::Upstream.find_or_insert(upstream)
-          record = self[upstream_id: upstream_id, name: gem_name.name, resource_type: resource_type.to_s]
+          upstream_id = Gemstash::DB::Upstream.find_or_insert(gem_name.upstream)
+          record = self[upstream_id: upstream_id, name: gem_name.name, resource_type: gem_name.type.to_s]
           return record.id if record
-          new(upstream_id: upstream_id, name: gem_name.name, resource_type: resource_type.to_s).tap(&:save).id
+          new(upstream_id: upstream_id, name: gem_name.name, resource_type: gem_name.type.to_s).tap(&:save).id
         end
       end
     end

--- a/lib/gemstash/env.rb
+++ b/lib/gemstash/env.rb
@@ -54,11 +54,8 @@ module Gemstash
     end
 
     def self.daemonized?
-      if @daemonized.nil?
-        raise "Daemonized hasn't been set yet!"
-      else
-        @daemonized
-      end
+      raise "Daemonized hasn't been set yet!" if @daemonized.nil?
+      @daemonized
     end
 
     def self.daemonized=(value)
@@ -108,10 +105,10 @@ module Gemstash
         when "sqlite3"
           db_path = base_file("gemstash.db")
 
-          if RUBY_PLATFORM == "java"
-            db = Sequel.connect("jdbc:sqlite:#{db_path}", max_connections: 1)
+          db = if RUBY_PLATFORM == "java"
+            Sequel.connect("jdbc:sqlite:#{db_path}", max_connections: 1)
           else
-            db = Sequel.connect("sqlite://#{URI.escape(db_path)}", max_connections: 1)
+            Sequel.connect("sqlite://#{URI.escape(db_path)}", max_connections: 1)
           end
         when "postgres", "mysql"
           db = Sequel.connect(config[:db_url])

--- a/lib/gemstash/gem_fetcher.rb
+++ b/lib/gemstash/gem_fetcher.rb
@@ -4,25 +4,43 @@ require "set"
 module Gemstash
   #:nodoc:
   class GemFetcher
+    include Gemstash::Logging
+
     def initialize(http_client)
       @http_client = http_client
       @valid_headers = Set.new(["etag", "content-type", "content-length", "last-modified"])
     end
 
     # Fetch the resource for the +gem_name+, returning a Gemstash::Resource
-    # where the resource is stored after fetching.
+    # where the resource is stored after fetching. If the gem already exists in
+    # storage, this will simply return the existing resource.
     #
     # @param gem_name [Gemstash::Upstream::GemName] the gem to fetch
     # @return [Gem::Resource] resource where the results are stored
     def fetch(gem_name)
+      if gem_name.resource.exist?(gem_name.type)
+        fetch_local(gem_name)
+      else
+        fetch_remote(gem_name)
+      end
+    end
+
+  private
+
+    def fetch_local(gem_name)
+      log.info "Gem #{gem_name.name} exists, returning cached #{gem_name.type}"
+      gem_name.resource
+    end
+
+    def fetch_remote(gem_name)
+      log.info "Gem #{gem_name.name} is not cached, fetching #{gem_name.type}"
+
       @http_client.get(gem_name.path) do |body, headers|
         properties = filter_headers(headers)
         validate_download(body, properties)
         store(gem_name, body, properties)
       end
     end
-
-  private
 
     def store(gem_name, body, properties)
       resource_properties = {

--- a/lib/gemstash/gem_fetcher.rb
+++ b/lib/gemstash/gem_fetcher.rb
@@ -4,8 +4,7 @@ require "set"
 module Gemstash
   #:nodoc:
   class GemFetcher
-    def initialize(storage, http_client)
-      @storage = storage
+    def initialize(http_client)
       @http_client = http_client
       @valid_headers = Set.new(["etag", "content-type", "content-length", "last-modified"])
     end
@@ -27,7 +26,7 @@ module Gemstash
   private
 
     def store(gem_name, type, body, properties)
-      gem_resource = @storage.resource(gem_name.name)
+      gem_resource = gem_name.upstream.storage.resource(gem_name.name)
 
       resource_properties = {
         upstream: gem_name.upstream.to_s,

--- a/lib/gemstash/gem_fetcher.rb
+++ b/lib/gemstash/gem_fetcher.rb
@@ -9,45 +9,31 @@ module Gemstash
       @valid_headers = Set.new(["etag", "content-type", "content-length", "last-modified"])
     end
 
-    # Fetch the resource type for the +gem_name+, returning a Gemstash::Resource
+    # Fetch the resource for the +gem_name+, returning a Gemstash::Resource
     # where the resource is stored after fetching.
     #
     # @param gem_name [Gemstash::Upstream::GemName] the gem to fetch
-    # @type type [Symbol] resource type, either :gem or :spec
     # @return [Gem::Resource] resource where the results are stored
-    def fetch(gem_name, type)
-      @http_client.get(path_for(gem_name.id, type)) do |body, headers|
+    def fetch(gem_name)
+      @http_client.get(gem_name.path) do |body, headers|
         properties = filter_headers(headers)
         validate_download(body, properties)
-        store(gem_name, type, body, properties)
+        store(gem_name, body, properties)
       end
     end
 
   private
 
-    def store(gem_name, type, body, properties)
-      gem_resource = gem_name.upstream.storage.resource(gem_name.name)
-
+    def store(gem_name, body, properties)
       resource_properties = {
         upstream: gem_name.upstream.to_s,
         gem_name: gem_name.name,
-        headers: { type => properties }
+        headers: { gem_name.type => properties }
       }
 
-      gem = gem_resource.save({ type => body }, resource_properties)
-      Gemstash::DB::CachedRubygem.store(gem_name.upstream, gem_name, type)
+      gem = gem_name.resource.save({ gem_name.type => body }, resource_properties)
+      Gemstash::DB::CachedRubygem.store(gem_name)
       gem
-    end
-
-    def path_for(gem_id, type)
-      case type
-      when :gem
-        "gems/#{gem_id}"
-      when :spec
-        "quick/Marshal.4.8/#{gem_id}"
-      else
-        raise "Invalid type #{type.inspect}"
-      end
     end
 
     def filter_headers(headers)

--- a/lib/gemstash/gem_fetcher.rb
+++ b/lib/gemstash/gem_fetcher.rb
@@ -4,20 +4,41 @@ require "set"
 module Gemstash
   #:nodoc:
   class GemFetcher
-    def initialize(http_client)
+    def initialize(storage, http_client)
+      @storage = storage
       @http_client = http_client
       @valid_headers = Set.new(["etag", "content-type", "content-length", "last-modified"])
     end
 
-    def fetch(gem_id, type, &block)
-      @http_client.get(path_for(gem_id, type)) do |body, headers|
+    # Fetch the resource type for the +gem_name+, returning a Gemstash::Resource
+    # where the resource is stored after fetching.
+    #
+    # @param gem_name [Gemstash::Upstream::GemName] the gem to fetch
+    # @type type [Symbol] resource type, either :gem or :spec
+    # @return [Gem::Resource] resource where the results are stored
+    def fetch(gem_name, type)
+      @http_client.get(path_for(gem_name.id, type)) do |body, headers|
         properties = filter_headers(headers)
         validate_download(body, properties)
-        yield body, properties
+        store(gem_name, type, body, properties)
       end
     end
 
   private
+
+    def store(gem_name, type, body, properties)
+      gem_resource = @storage.resource(gem_name.name)
+
+      resource_properties = {
+        upstream: gem_name.upstream.to_s,
+        gem_name: gem_name.name,
+        headers: { type => properties }
+      }
+
+      gem = gem_resource.save({ type => body }, resource_properties)
+      Gemstash::DB::CachedRubygem.store(gem_name.upstream, gem_name, type)
+      gem
+    end
 
     def path_for(gem_id, type)
       case type

--- a/lib/gemstash/gem_pusher.rb
+++ b/lib/gemstash/gem_pusher.rb
@@ -66,11 +66,13 @@ module Gemstash
         existing = Gemstash::DB::Version.find_by_spec(gem_id, spec)
 
         if existing
+          # rubocop:disable Style/GuardClause
           if existing.indexed
             raise ExistingVersionError, "Cannot push to an existing version!"
           else
             raise YankedVersionError, "Cannot push to a yanked version!"
           end
+          # rubocop:enable Style/GuardClause
         end
 
         version_id = Gemstash::DB::Version.insert_by_spec(gem_id, spec)

--- a/lib/gemstash/gem_source.rb
+++ b/lib/gemstash/gem_source.rb
@@ -23,8 +23,6 @@ module Gemstash
     # Base GemSource for some common utilities.
     class Base
       extend Forwardable
-      extend Gemstash::Logging
-      include Gemstash::Logging
 
       def_delegators :@app, :cache_control, :content_type, :env, :halt,
         :headers, :http_client_for, :params, :redirect, :request

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -139,7 +139,7 @@ module Gemstash
       end
 
       def gem_fetcher
-        @gem_fetcher ||= Gemstash::GemFetcher.new(http_client_for(upstream))
+        @gem_fetcher ||= Gemstash::GemFetcher.new(storage, http_client_for(upstream))
       end
 
       def fetch_gem(id, resource_type)
@@ -148,7 +148,7 @@ module Gemstash
         if gem_resource.exist?(resource_type)
           fetch_local_gem(gem_name, gem_resource, resource_type)
         else
-          fetch_remote_gem(gem_name, gem_resource, resource_type)
+          fetch_remote_gem(gem_name, resource_type)
         end
       end
 
@@ -157,19 +157,9 @@ module Gemstash
         gem_resource
       end
 
-      def fetch_remote_gem(gem_name, gem_resource, resource_type)
+      def fetch_remote_gem(gem_name, resource_type)
         log.info "Gem #{gem_name.name} is not cached, fetching #{resource_type}"
-        gem_fetcher.fetch(gem_name.id, resource_type) do |content, properties|
-          resource_properties = {
-            upstream: upstream.to_s,
-            gem_name: gem_name.name,
-            headers: { resource_type => properties }
-          }
-
-          gem = gem_resource.save({ resource_type => content }, resource_properties)
-          Gemstash::DB::CachedRubygem.store(upstream, gem_name, resource_type)
-          gem
-        end
+        gem_fetcher.fetch(gem_name, resource_type)
       end
     end
 

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -146,10 +146,10 @@ module Gemstash
     # default upstream).
     class RubygemsSource < Gemstash::GemSource::UpstreamSource
       def self.matches?(env)
-        if env["HTTP_X_GEMFILE_SOURCE"].to_s.empty?
-          env["gemstash.upstream"] = env["gemstash.env"].config[:rubygems_url]
+        env["gemstash.upstream"] = if env["HTTP_X_GEMFILE_SOURCE"].to_s.empty?
+          env["gemstash.env"].config[:rubygems_url]
         else
-          env["gemstash.upstream"] = env["HTTP_X_GEMFILE_SOURCE"]
+          env["HTTP_X_GEMFILE_SOURCE"]
         end
         capture_user_agent(env)
 

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -138,23 +138,7 @@ module Gemstash
       end
 
       def fetch_gem(id, resource_type)
-        gem_name = upstream.gem_name(id, resource_type)
-
-        if gem_name.resource.exist?(gem_name.type)
-          fetch_local_gem(gem_name)
-        else
-          fetch_remote_gem(gem_name)
-        end
-      end
-
-      def fetch_local_gem(gem_name)
-        log.info "Gem #{gem_name.name} exists, returning cached #{gem_name.type}"
-        gem_name.resource
-      end
-
-      def fetch_remote_gem(gem_name)
-        log.info "Gem #{gem_name.name} is not cached, fetching #{gem_name.type}"
-        gem_fetcher.fetch(gem_name)
+        gem_fetcher.fetch upstream.gem_name(id, resource_type)
       end
     end
 

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -138,7 +138,7 @@ module Gemstash
       end
 
       def fetch_gem(id, resource_type)
-        gem_name = Gemstash::Upstream::GemName.new(upstream, id)
+        gem_name = upstream.gem_name(id)
         gem_resource = upstream.storage.resource(gem_name.name)
         if gem_resource.exist?(resource_type)
           fetch_local_gem(gem_name, gem_resource, resource_type)

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -133,18 +133,13 @@ module Gemstash
         end
       end
 
-      def storage
-        @storage ||= Gemstash::Storage.for("gem_cache")
-        @storage.for(upstream.host_id)
-      end
-
       def gem_fetcher
-        @gem_fetcher ||= Gemstash::GemFetcher.new(storage, http_client_for(upstream))
+        @gem_fetcher ||= Gemstash::GemFetcher.new(http_client_for(upstream))
       end
 
       def fetch_gem(id, resource_type)
         gem_name = Gemstash::Upstream::GemName.new(upstream, id)
-        gem_resource = storage.resource(gem_name.name)
+        gem_resource = upstream.storage.resource(gem_name.name)
         if gem_resource.exist?(resource_type)
           fetch_local_gem(gem_name, gem_resource, resource_type)
         else

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -138,23 +138,23 @@ module Gemstash
       end
 
       def fetch_gem(id, resource_type)
-        gem_name = upstream.gem_name(id)
-        gem_resource = upstream.storage.resource(gem_name.name)
-        if gem_resource.exist?(resource_type)
-          fetch_local_gem(gem_name, gem_resource, resource_type)
+        gem_name = upstream.gem_name(id, resource_type)
+
+        if gem_name.resource.exist?(gem_name.type)
+          fetch_local_gem(gem_name)
         else
-          fetch_remote_gem(gem_name, resource_type)
+          fetch_remote_gem(gem_name)
         end
       end
 
-      def fetch_local_gem(gem_name, gem_resource, resource_type)
-        log.info "Gem #{gem_name.name} exists, returning cached #{resource_type}"
-        gem_resource
+      def fetch_local_gem(gem_name)
+        log.info "Gem #{gem_name.name} exists, returning cached #{gem_name.type}"
+        gem_name.resource
       end
 
-      def fetch_remote_gem(gem_name, resource_type)
-        log.info "Gem #{gem_name.name} is not cached, fetching #{resource_type}"
-        gem_fetcher.fetch(gem_name, resource_type)
+      def fetch_remote_gem(gem_name)
+        log.info "Gem #{gem_name.name} is not cached, fetching #{gem_name.type}"
+        gem_fetcher.fetch(gem_name)
       end
     end
 

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -24,7 +24,7 @@ module Gemstash
   class HTTPClient
     include Gemstash::Logging
 
-    DEFAULT_USER_AGENT = "Gemstash/#{Gemstash::VERSION}"
+    DEFAULT_USER_AGENT = "Gemstash/#{Gemstash::VERSION}".freeze
 
     def self.for(upstream)
       client = Faraday.new(upstream.to_s) do |config|
@@ -73,11 +73,11 @@ module Gemstash
       response
     end
 
-    def with_retries(times: 3, &block)
+    def with_retries(times: 3)
       loop do
         times -= 1
         begin
-          return block.call
+          return yield
         rescue Faraday::ConnectionFailed => e
           log_error("Connection failure", e)
           raise(ConnectionError, e.message) unless times > 0

--- a/lib/gemstash/logging.rb
+++ b/lib/gemstash/logging.rb
@@ -10,7 +10,7 @@ module Gemstash
       warn: Logger::WARN,
       error: Logger::ERROR,
       fatal: Logger::FATAL
-    }
+    }.freeze
 
     def log
       Gemstash::Logging.logger

--- a/lib/gemstash/preload.rb
+++ b/lib/gemstash/preload.rb
@@ -57,7 +57,7 @@ module Gemstash
     class GemSpecs
       extend Forwardable
 
-      def_delegators :@specs, :each, :size, :each_with_index, :[], :first, :last, :empty?
+      def_delegators :@specs, :each, :map, :size, :each_with_index, :[], :first, :last, :empty?
 
       def initialize(upstream, http_client, filename = GemSpecFilename.new)
         @upstream = upstream
@@ -69,23 +69,12 @@ module Gemstash
         begin
           reader = Zlib::GzipReader.new(StringIO.new(@http_client.get(@specs_file)))
           @specs = Marshal.load(reader.read).inject([]) do |specs, gem_spec|
-            specs << GemName.new(gem_spec)
+            specs << @upstream.gem_name(gem_spec)
           end
         ensure
           reader.close if reader
         end
         self
-      end
-    end
-
-    #:nodoc:
-    class GemName
-      def initialize(gem)
-        (@name, @version, _ignored) = gem
-      end
-
-      def to_s
-        "#{@name}-#{@version}"
       end
     end
   end

--- a/lib/gemstash/preload.rb
+++ b/lib/gemstash/preload.rb
@@ -69,7 +69,7 @@ module Gemstash
         begin
           reader = Zlib::GzipReader.new(StringIO.new(@http_client.get(@specs_file)))
           @specs = Marshal.load(reader.read).inject([]) do |specs, gem_spec|
-            specs << @upstream.gem_name(gem_spec)
+            specs << @upstream.gem_name(gem_spec, :gem)
           end
         ensure
           reader.close if reader

--- a/lib/gemstash/preload.rb
+++ b/lib/gemstash/preload.rb
@@ -8,12 +8,13 @@ module Gemstash
   module Preload
     #:nodoc:
     class GemPreloader
-      def initialize(http_client, options = {})
+      def initialize(upstream, http_client, options = {})
+        @upstream = upstream
         @http_client = http_client
         @threads = options[:threads] || 20
         @skip = options[:skip] || 0
         @limit = options[:limit]
-        @specs = GemSpecs.new(http_client, GemSpecFilename.new(options))
+        @specs = GemSpecs.new(upstream, http_client, GemSpecFilename.new(options))
       end
 
       def preload
@@ -58,7 +59,8 @@ module Gemstash
 
       def_delegators :@specs, :each, :size, :each_with_index, :[], :first, :last, :empty?
 
-      def initialize(http_client, filename = GemSpecFilename.new)
+      def initialize(upstream, http_client, filename = GemSpecFilename.new)
+        @upstream = upstream
         @http_client = http_client
         @specs_file = filename.to_s
       end

--- a/lib/gemstash/puma.rb
+++ b/lib/gemstash/puma.rb
@@ -1,6 +1,6 @@
 require "gemstash"
 
 threads 0, 16
-bind "#{Gemstash::Env.current.config[:bind]}"
+bind Gemstash::Env.current.config[:bind].to_s
 workers 1
 rackup Gemstash::Env.current.rackup

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -44,6 +44,8 @@ module Gemstash
 
     #:nodoc:
     class GemName
+      attr_reader :upstream
+
       def initialize(upstream, gem_name)
         @upstream = upstream
         @id = gem_name

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -36,6 +36,10 @@ module Gemstash
       @host_id ||= "#{host}_#{hash}"
     end
 
+    def storage
+      @storage ||= Gemstash::Storage.for("gem_cache").for(host_id)
+    end
+
   private
 
     def hash

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -58,10 +58,10 @@ module Gemstash
         @upstream = upstream
         @type = type
 
-        if gem_name.is_a?(Array)
-          @name = from_spec_array(gem_name)
+        @name = if gem_name.is_a?(Array)
+          from_spec_array(gem_name)
         else
-          @name = gem_name.gsub(/\.gem(spec\.rz)?$/i, "")
+          gem_name.gsub(/\.gem(spec\.rz)?$/i, "")
         end
       end
 

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -40,6 +40,10 @@ module Gemstash
       @storage ||= Gemstash::Storage.for("gem_cache").for(host_id)
     end
 
+    def gem_name(name)
+      Gemstash::Upstream::GemName.new(self, name)
+    end
+
   private
 
     def hash
@@ -52,7 +56,12 @@ module Gemstash
 
       def initialize(upstream, gem_name)
         @upstream = upstream
-        @id = gem_name
+
+        if gem_name.is_a?(Array)
+          @id = from_spec_array(gem_name)
+        else
+          @id = gem_name
+        end
       end
 
       def to_s
@@ -65,6 +74,18 @@ module Gemstash
 
       def name
         @name ||= @id.gsub(/\.gem(spec\.rz)?$/i, "")
+      end
+
+    private
+
+      def from_spec_array(spec)
+        raise "Expected spec array to be of length 3!" if spec.size != 3
+
+        if spec[2] == "ruby"
+          spec[0, 2].join("-")
+        else
+          spec.join("-")
+        end
       end
     end
   end

--- a/lib/gemstash/version.rb
+++ b/lib/gemstash/version.rb
@@ -1,4 +1,4 @@
 #:nodoc:
 module Gemstash
-  VERSION = "1.0.0"
+  VERSION = "1.0.0".freeze
 end

--- a/rake/changelog.rb
+++ b/rake/changelog.rb
@@ -60,7 +60,7 @@ class Changelog
         puts "And store it at: #{token_path}"
         puts "Otherwise you might hit rate limits while running this"
         print "Continue without token? [yes/no] "
-        abort("Please create your token and retry") unless STDIN.gets.strip.downcase == "yes"
+        abort("Please create your token and retry") unless STDIN.gets.strip.casecmp("yes") == 0
         options = {}
       end
 

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -118,11 +118,8 @@ describe Gemstash::HTTPClient do
         it "retries 3 times on connection error" do
           exceptions = [Faraday::ConnectionFailed, Faraday::ConnectionFailed]
           stubs.get("/gems/rack", "User-Agent" => default_user_agent) do
-            if exceptions.empty?
-              [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"]
-            else
-              raise exceptions.pop, "I don't like your DNS query!"
-            end
+            raise exceptions.pop, "I don't like your DNS query!" unless exceptions.empty?
+            [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"]
           end
           expect(http_client.get("/gems/rack")).to eq("zapatito")
           expect(exceptions).to be_empty

--- a/spec/gemstash/preload_spec.rb
+++ b/spec/gemstash/preload_spec.rb
@@ -66,22 +66,22 @@ describe Gemstash::Preload do
     end
   end
 
-  describe Gemstash::Preload::GemPreloader do
+  describe Gemstash::Preload::GemPreloader, db_transaction: false do
     let(:out) { StringIO.new }
 
     before do
       stubs.get("specs.4.8.gz") do
         [200, { "CONTENT-TYPE" => "octet/stream" }, full_specs]
       end
-      stubs.head("gems/latest_gem-1.0.0.gem") do
+      stubs.get("gems/latest_gem-1.0.0.gem") do
         out.write("gems/latest_gem-1.0.0.gem\n")
         [200, { "CONTENT-TYPE" => "octet/stream" }, "The latest gem"]
       end
-      stubs.head("gems/other-0.1.0.gem") do
+      stubs.get("gems/other-0.1.0.gem") do
         out.write("gems/other-0.1.0.gem\n")
         [200, { "CONTENT-TYPE" => "octet/stream" }, "The other gem"]
       end
-      stubs.head("gems/other_platform-0.1.0-java.gem") do
+      stubs.get("gems/other_platform-0.1.0-java.gem") do
         out.write("gems/other_platform-0.1.0-java.gem\n")
         [200, { "CONTENT-TYPE" => "octet/stream" }, "The other platform gem"]
       end

--- a/spec/gemstash/preload_spec.rb
+++ b/spec/gemstash/preload_spec.rb
@@ -3,6 +3,7 @@ require "faraday"
 
 describe Gemstash::Preload do
   let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+  let(:upstream) { Gemstash::Upstream.new("https://example.com") }
   let(:http_client) { Gemstash::HTTPClient.new(Faraday.new {|builder| builder.adapter(:test, stubs) }) }
   let(:latest_specs) do
     gzip(Marshal.dump([["latest_gem", "1.0.0", "ruby"]]))
@@ -41,7 +42,7 @@ describe Gemstash::Preload do
       stubs.get("specs.4.8.gz") do
         [200, { "CONTENT-TYPE" => "octet/stream" }, full_specs]
       end
-      specs = Gemstash::Preload::GemSpecs.new(http_client).fetch
+      specs = Gemstash::Preload::GemSpecs.new(upstream, http_client).fetch
       expect(specs).not_to be_empty
       expect(specs.first.to_s).to eq("latest_gem-1.0.0")
       expect(specs.last.to_s).to eq("other-0.1.0")
@@ -51,7 +52,7 @@ describe Gemstash::Preload do
       stubs.get("latest_specs.4.8.gz") do
         [200, { "CONTENT-TYPE" => "octet/stream" }, latest_specs]
       end
-      specs = Gemstash::Preload::GemSpecs.new(http_client, latest).fetch
+      specs = Gemstash::Preload::GemSpecs.new(upstream, http_client, latest).fetch
       expect(specs.last.to_s).to eq("latest_gem-1.0.0")
     end
 
@@ -59,7 +60,7 @@ describe Gemstash::Preload do
       stubs.get("prerelease_specs.4.8.gz") do
         [200, { "CONTENT-TYPE" => "octet/stream" }, prerelease_specs]
       end
-      specs = Gemstash::Preload::GemSpecs.new(http_client, prerelease).fetch
+      specs = Gemstash::Preload::GemSpecs.new(upstream, http_client, prerelease).fetch
       expect(specs.last.to_s).to eq("prerelease_gem-0.9.0")
     end
   end
@@ -82,37 +83,37 @@ describe Gemstash::Preload do
     end
 
     it "Preloads all the gems included in the specs file" do
-      Gemstash::Preload::GemPreloader.new(http_client).preload
+      Gemstash::Preload::GemPreloader.new(upstream, http_client).preload
       stubs.verify_stubbed_calls
     end
 
     it "Skips gems as requested" do
-      Gemstash::Preload::GemPreloader.new(http_client, skip: 1).preload
+      Gemstash::Preload::GemPreloader.new(upstream, http_client, skip: 1).preload
       expect(out.string).to eq("gems/other-0.1.0.gem\n")
     end
 
     it "Loads as many gems as requested" do
-      Gemstash::Preload::GemPreloader.new(http_client, limit: 1).preload
+      Gemstash::Preload::GemPreloader.new(upstream, http_client, limit: 1).preload
       expect(out.string).to eq("gems/latest_gem-1.0.0.gem\n")
     end
 
     it "Loads only the last gem when requested" do
-      Gemstash::Preload::GemPreloader.new(http_client, skip: 1, limit: 1).preload
+      Gemstash::Preload::GemPreloader.new(upstream, http_client, skip: 1, limit: 1).preload
       expect(out.string).to eq("gems/other-0.1.0.gem\n")
     end
 
     it "Loads no gem at all when the skip is larger than the size" do
-      Gemstash::Preload::GemPreloader.new(http_client, skip: 3).preload
+      Gemstash::Preload::GemPreloader.new(upstream, http_client, skip: 3).preload
       expect(out.string).to be_empty
     end
 
     it "Loads no gem at all when the limit is zero" do
-      Gemstash::Preload::GemPreloader.new(http_client, limit: 0).preload
+      Gemstash::Preload::GemPreloader.new(upstream, http_client, limit: 0).preload
       expect(out.string).to be_empty
     end
 
     it "Loads in order when using only one thread" do
-      Gemstash::Preload::GemPreloader.new(http_client, threads: 1).preload
+      Gemstash::Preload::GemPreloader.new(upstream, http_client, threads: 1).preload
       expect(out.string).to eq("gems/latest_gem-1.0.0.gem\ngems/other-0.1.0.gem\n")
     end
   end

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -96,31 +96,37 @@ describe Gemstash::Upstream::GemName do
     let(:upstream) { Gemstash::Upstream.new("https://rubygems.org/") }
 
     it "resolves to the gem name" do
-      expect(upstream.gem_name("mygemname").to_s).to eq("mygemname")
+      expect(upstream.gem_name("mygemname", :gem).to_s).to eq("mygemname")
     end
 
     it "removes the trailing .gem from the name" do
-      gem_name = upstream.gem_name("mygemname-1.0.1.gem")
-      expect(gem_name.id).to eq("mygemname-1.0.1.gem")
+      gem_name = upstream.gem_name("mygemname-1.0.1.gem", :gem)
       expect(gem_name.name).to eq("mygemname-1.0.1")
     end
 
     it "removes the trailing .gemspec.rz from the name" do
-      gem_name = upstream.gem_name("mygemname-1.0.1.gemspec.rz")
-      expect(gem_name.id).to eq("mygemname-1.0.1.gemspec.rz")
+      gem_name = upstream.gem_name("mygemname-1.0.1.gemspec.rz", :gem)
       expect(gem_name.name).to eq("mygemname-1.0.1")
     end
 
     it "can take the serialized spec array" do
-      gem_name = upstream.gem_name(["mygemname", Gem::Version.new("1.0.1"), "ruby"])
-      expect(gem_name.id).to eq("mygemname-1.0.1")
+      gem_name = upstream.gem_name(["mygemname", Gem::Version.new("1.0.1"), "ruby"], :gem)
       expect(gem_name.name).to eq("mygemname-1.0.1")
     end
 
     it "can take the serialized spec array with a different platform" do
-      gem_name = upstream.gem_name(["mygemname", Gem::Version.new("1.0.1"), "java"])
-      expect(gem_name.id).to eq("mygemname-1.0.1-java")
+      gem_name = upstream.gem_name(["mygemname", Gem::Version.new("1.0.1"), "java"], :gem)
       expect(gem_name.name).to eq("mygemname-1.0.1-java")
+    end
+
+    it "can have :gem type for a gem path" do
+      gem_name = upstream.gem_name("mygemname-1.0.1.gem", :gem)
+      expect(gem_name.path).to eq("gems/mygemname-1.0.1.gem")
+    end
+
+    it "can have :spec type for a gemspec path" do
+      gem_name = upstream.gem_name("mygemname-1.0.1.gemspec.rz", :spec)
+      expect(gem_name.path).to eq("quick/Marshal.4.8/mygemname-1.0.1.gemspec.rz")
     end
   end
 end

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -96,19 +96,31 @@ describe Gemstash::Upstream::GemName do
     let(:upstream) { Gemstash::Upstream.new("https://rubygems.org/") }
 
     it "resolves to the gem name" do
-      expect(Gemstash::Upstream::GemName.new(upstream, "mygemname").to_s).to eq("mygemname")
+      expect(upstream.gem_name("mygemname").to_s).to eq("mygemname")
     end
 
     it "removes the trailing .gem from the name" do
-      gem_name = Gemstash::Upstream::GemName.new(upstream, "mygemname-1.0.1.gem")
+      gem_name = upstream.gem_name("mygemname-1.0.1.gem")
       expect(gem_name.id).to eq("mygemname-1.0.1.gem")
       expect(gem_name.name).to eq("mygemname-1.0.1")
     end
 
     it "removes the trailing .gemspec.rz from the name" do
-      gem_name = Gemstash::Upstream::GemName.new(upstream, "mygemname-1.0.1.gemspec.rz")
+      gem_name = upstream.gem_name("mygemname-1.0.1.gemspec.rz")
       expect(gem_name.id).to eq("mygemname-1.0.1.gemspec.rz")
       expect(gem_name.name).to eq("mygemname-1.0.1")
+    end
+
+    it "can take the serialized spec array" do
+      gem_name = upstream.gem_name(["mygemname", Gem::Version.new("1.0.1"), "ruby"])
+      expect(gem_name.id).to eq("mygemname-1.0.1")
+      expect(gem_name.name).to eq("mygemname-1.0.1")
+    end
+
+    it "can take the serialized spec array with a different platform" do
+      gem_name = upstream.gem_name(["mygemname", Gem::Version.new("1.0.1"), "java"])
+      expect(gem_name.id).to eq("mygemname-1.0.1-java")
+      expect(gem_name.name).to eq("mygemname-1.0.1-java")
     end
   end
 end

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -87,7 +87,7 @@ describe Gemstash::Web do
     end
 
     context "there are too many gems" do
-      let(:gems) { 201.times.map {|i| "gem-#{i}" }.join(",") }
+      let(:gems) { Array.new(201) {|i| "gem-#{i}" }.join(",") }
 
       it "returns a 422" do
         get "#{request}?gems=#{gems}", {}, rack_env
@@ -141,7 +141,7 @@ describe Gemstash::Web do
     end
 
     context "there are too many gems" do
-      let(:gems) { 201.times.map {|i| "gem-#{i}" }.join(",") }
+      let(:gems) { Array.new(201) {|i| "gem-#{i}" }.join(",") }
 
       it "returns a 422" do
         error = {

--- a/spec/gemstash/web_spec.rb
+++ b/spec/gemstash/web_spec.rb
@@ -11,7 +11,7 @@ describe Gemstash::Web do
     class StubHttpBuilder
       def for(server_url)
         stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.get("/gems/rack") { [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"] }
+          stub.get("/gems/rack.gem") { [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito"] }
           stub.get("/gems/rack-1.0.0.gem") { [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito-1.0.0"] }
           stub.get("/gems/rack-1.1.0.gem") { [200, { "CONTENT-TYPE" => "octet/stream" }, "zapatito-1.1.0"] }
           stub.get("/quick/Marshal.4.8/rack.gemspec.rz") { [200, { "CONTENT-TYPE" => "octet/stream" }, "specatito"] }

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -14,10 +14,10 @@ module DBHelpers
   def insert_version(gem_id, number, platform: "ruby", indexed: true, prerelease: false)
     gem_name = Gemstash::Env.current.db[:rubygems][:id => gem_id][:name]
 
-    if platform == "ruby"
-      storage_id = "#{gem_name}-#{number}"
+    storage_id = if platform == "ruby"
+      "#{gem_name}-#{number}"
     else
-      storage_id = "#{gem_name}-#{number}-#{platform}"
+      "#{gem_name}-#{number}-#{platform}"
     end
 
     Gemstash::Env.current.db[:versions].insert(


### PR DESCRIPTION
Move execution of the preload into the server side context.

While developing this, I ran into the following error:

```
$ rspec ./spec/gemstash/preload_spec.rb

Gemstash::Preload
  Gemstash::Preload::GemSpecFilename
    fails when both latest and prerelease is set to true
    returns the default spec file by default
    returns the prerelease spec file with prerelease: true
    returns the latest spec file with latest: true
  Gemstash::Preload::GemSpecs
    GemSpecs fetches the full specs by default
    fetches the latest specs when requested
    fetches the prerelease specs when requested
  Gemstash::Preload::GemPreloader
    with no cached gems
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      Preloads all the gems included in the specs file (FAILED - 1)
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      Skips gems as requested
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      Loads as many gems as requested
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      Loads only the last gem when requested
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      Loads no gem at all when the skip is larger than the size
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      Loads no gem at all when the limit is zero
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      Loads in order when using only one thread
downloading gems |Time: 00:00:00 | ================================================================================================================================== | Time: 00:00:00
      stores the gems

Failures:

  1) Gemstash::Preload Gemstash::Preload::GemPreloader with no cached gems Preloads all the gems included in the specs file
     Failure/Error: Unable to find matching line from backtrace
     NoMethodError:
       undefined method `[]' for false:FalseClass
     # ./lib/gemstash/storage.rb:73:in `check_storage_version'
     # ./lib/gemstash/storage.rb:27:in `initialize'
     # ./lib/gemstash/storage.rb:52:in `new'
     # ./lib/gemstash/storage.rb:52:in `for'
     # ./lib/gemstash/upstream.rb:40:in `storage'
     # ./lib/gemstash/upstream.rb:73:in `resource'
     # ./lib/gemstash/gem_fetcher.rb:34:in `store'
     # ./lib/gemstash/gem_fetcher.rb:21:in `block in fetch'
     # ./lib/gemstash/http_client.rb:48:in `get'
     # ./lib/gemstash/gem_fetcher.rb:18:in `fetch'
     # ./lib/gemstash/preload.rb:25:in `block in preload'
     # ~/.rvm/gems/ruby-2.2.2/gems/parallel-1.6.1/lib/parallel.rb:408:in `call'
     # ~/.rvm/gems/ruby-2.2.2/gems/parallel-1.6.1/lib/parallel.rb:408:in `call_with_index'
     # ~/.rvm/gems/ruby-2.2.2/gems/parallel-1.6.1/lib/parallel.rb:288:in `block (2 levels) in work_in_threads'
     # ~/.rvm/gems/ruby-2.2.2/gems/parallel-1.6.1/lib/parallel.rb:419:in `with_instrumentation'
     # ~/.rvm/gems/ruby-2.2.2/gems/parallel-1.6.1/lib/parallel.rb:287:in `block in work_in_threads'
     # ~/.rvm/gems/ruby-2.2.2/gems/parallel-1.6.1/lib/parallel.rb:183:in `block (2 levels) in in_threads'

Finished in 4.22 seconds (files took 0.6387 seconds to load)
15 examples, 1 failure

Failed examples:

rspec ./spec/gemstash/preload_spec.rb:92 # Gemstash::Preload Gemstash::Preload::GemPreloader with no cached gems Preloads all the gems included in the specs file

$ irb
2.2.2 :001 > require "yaml"
 => true
2.2.2 :002 > File.write "tmp.txt", ""
 => 0
2.2.2 :003 > YAML.load_file("tmp.txt")
 => false
2.2.2 :004 >
```

As I illustrated in the IRB session, this seems to only be possible if the metadata gets initially created, and then written... thus creating a possible race condition where the file may exist before being written to. _Does this mean we may have other file writing race conditions...?_
