### PR TITLE
Serve 404 if the source doesn't implement /api/v1/dependencies

### DIFF
--- a/lib/gemstash/web.rb
+++ b/lib/gemstash/web.rb
@@ -31,7 +31,15 @@ module Gemstash
     end
 
     get "/api/v1/dependencies" do
-      @gem_source.serve_dependencies
+      begin
+        @gem_source.serve_dependencies
+      rescue Gemstash::WebError => web_error
+        if web_error.code == 404
+          status 404
+        else
+          raise web_error
+        end
+      end
     end
 
     get "/api/v1/dependencies.json" do


### PR DESCRIPTION
This is spawned from https://github.com/bundler/gemstash/issues/163

Not all sources implement the `/api/v1/dependencies` endpoint, instead
serving dependencies from the full index path. Bundler currently handles
this endpoint returning a 404, which allows these sources to work when
referenced directly, just not proxied through gemstash.

This updates gemstash to return a 404 status code if the source returns
a 404 on this endpoint, rather than raising a Gemstash::WebError. It
will still raise an error for all other error codes.