### PR TITLE
Add name field to authorizations (gemstash authorize)

### DIFF
--- a/docs/gemstash-authorize.1.md
+++ b/docs/gemstash-authorize.1.md
@@ -7,7 +7,7 @@ gemstash-authorize - Adds or removes authorization to interact with privately st
 Synopsis
 ========
 
-`gemstash authorize [permissions] [--remove] [--key SECURE_KEY] [--config-file FILE]`
+`gemstash authorize [permissions] [--remove] [--key SECURE_KEY] [--config-file FILE] [--name NAME]`
 
 Description
 ===========
@@ -21,7 +21,9 @@ Usage
 
     gemstash authorize
     gemstash authorize push yank
+    gemstash authorize push yank --name <somename>
     gemstash authorize yank --key <secure-key>
+    gemstash authorize yank --key <secure-key> --name <somename>
     gemstash authorize --remove --key <secure-key>
 
 Options
@@ -32,3 +34,5 @@ Options
 -   `--key SECURE_KEY`: Specify the API key to affect. This should be the actual key value, not a name. This option is required when using `--remove` but is optional otherwise. If adding an authorization, using this will either create or update the permissions for the specified API key. If missing, a new API key will always be generated. Note that a key can only have a maximum length of 255 chars.
 
 -   `--remove`: Remove an authorization rather than add or update one. When removing, permission values are not allowed. The `--key <secure-key>` option is required.
+
+-   `--name`: Optional, specifies an identifiable name for the respective key. Useful if you are assigning these to users or systems, and want to keep track.

--- a/lib/gemstash/authorization.rb
+++ b/lib/gemstash/authorization.rb
@@ -11,7 +11,7 @@ module Gemstash
     extend Gemstash::Logging
     VALID_PERMISSIONS = %w(push yank fetch).freeze
 
-    def self.authorize(auth_key, permissions)
+    def self.authorize(auth_key, permissions, name = "")
       raise "Authorization key is required!" if auth_key.to_s.strip.empty?
       raise "Permissions are required!" if permissions.to_s.empty?
 
@@ -25,9 +25,9 @@ module Gemstash
         permissions = permissions.join(",")
       end
 
-      Gemstash::DB::Authorization.insert_or_update(auth_key, permissions)
+      Gemstash::DB::Authorization.insert_or_update(auth_key, permissions, name)
       gemstash_env.cache.invalidate_authorization(auth_key)
-      log.info "Authorization '#{auth_key}' updated with access to '#{permissions}'"
+      log.info "Authorization '#{auth_key}' updated (with name '#{name}') with access to '#{permissions}'"
     end
 
     def self.remove(auth_key)

--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -53,6 +53,8 @@ module Gemstash
       "Config file to save to"
     method_option :key, :type => :string, :desc =>
       "Authorization key to create/update/delete (optional unless deleting)"
+    method_option :name, :type => :string, :desc =>
+      "Name for the key (optional)"
     def authorize(*args)
       Gemstash::CLI::Authorize.new(self, *args).run
     end

--- a/lib/gemstash/cli/authorize.rb
+++ b/lib/gemstash/cli/authorize.rb
@@ -41,7 +41,7 @@ Instead just authorize with the new set of permissions") unless @args.empty?
           end
         end
 
-        Gemstash::Authorization.authorize(auth_key, permissions)
+        Gemstash::Authorization.authorize(auth_key, permissions, name)
       end
 
       def auth_key(allow_generate = true)
@@ -62,6 +62,14 @@ Instead just authorize with the new set of permissions") unless @args.empty?
           "all"
         else
           @args
+        end
+      end
+
+      def name
+        if @cli.options[:name].empty?
+          ""
+        else
+          @cli.options[:name]
         end
       end
     end

--- a/lib/gemstash/migrations/04_add_name_to_authorizations.rb
+++ b/lib/gemstash/migrations/04_add_name_to_authorizations.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  up do
+    alter_table :authorizations do
+      add_column :name, String, :size => 191, :null => false, :default => ""
+    end
+  end
+  down do
+    alter_table :authorizations do
+      drop_column :name
+    end
+  end
+end

--- a/spec/gemstash/gem_pusher_spec.rb
+++ b/spec/gemstash/gem_pusher_spec.rb
@@ -6,13 +6,15 @@ describe Gemstash::GemPusher do
   let(:auth_with_invalid_auth_key) { Gemstash::ApiKeyAuthorization.new(invalid_auth_key) }
   let(:auth_without_permission) { Gemstash::ApiKeyAuthorization.new(auth_key_without_permission) }
   let(:auth_key) { "auth-key" }
+  let(:auth_key_name) { "somekey" }
   let(:invalid_auth_key) { "invalid-auth-key" }
   let(:auth_key_without_permission) { "auth-key-without-permission" }
+  let(:auth_key_without_permission_name) { "badkey" }
   let(:storage) { Gemstash::Storage.for("private").for("gems") }
 
   before do
-    Gemstash::Authorization.authorize(auth_key, "all")
-    Gemstash::Authorization.authorize(auth_key_without_permission, ["yank"])
+    Gemstash::Authorization.authorize(auth_key, "all", auth_key_name)
+    Gemstash::Authorization.authorize(auth_key_without_permission, ["yank"], auth_key_without_permission_name)
   end
 
   describe ".serve" do

--- a/spec/gemstash/gem_yanker_spec.rb
+++ b/spec/gemstash/gem_yanker_spec.rb
@@ -5,8 +5,10 @@ describe Gemstash::GemYanker do
   let(:auth_with_invalid_auth_key) { Gemstash::ApiKeyAuthorization.new(invalid_auth_key) }
   let(:auth_without_permission) { Gemstash::ApiKeyAuthorization.new(auth_key_without_permission) }
   let(:auth_key) { "auth-key" }
+  let(:auth_key_name) { "somekey" }
   let(:invalid_auth_key) { "invalid-auth-key" }
   let(:auth_key_without_permission) { "auth-key-without-permission" }
+  let(:auth_key_without_permission_name) { "badkey" }
   let(:storage) { Gemstash::Storage.for("private").for("gems") }
   let(:deps) { Gemstash::Dependencies.for_private }
   let(:gem_name) { "example" }
@@ -24,8 +26,8 @@ describe Gemstash::GemYanker do
   end
 
   before do
-    Gemstash::Authorization.authorize(auth_key, "all")
-    Gemstash::Authorization.authorize(auth_key_without_permission, ["push"])
+    Gemstash::Authorization.authorize(auth_key, "all", auth_key_name)
+    Gemstash::Authorization.authorize(auth_key_without_permission, ["push"], auth_key_without_permission_name)
     Gemstash::GemPusher.new(auth, read_gem(gem_name, gem_version)).serve
   end
 

--- a/spec/gemstash/specs_builder_spec.rb
+++ b/spec/gemstash/specs_builder_spec.rb
@@ -5,12 +5,14 @@ describe Gemstash::SpecsBuilder do
   let(:auth_with_invalid_auth_key) { Gemstash::ApiKeyAuthorization.new(invalid_auth_key) }
   let(:auth_without_permission) { Gemstash::ApiKeyAuthorization.new(auth_key_without_permission) }
   let(:auth_key) { "auth-key" }
+  let(:auth_key_name) { "somekey" }
   let(:invalid_auth_key) { "invalid-auth-key" }
   let(:auth_key_without_permission) { "auth-key-without-permission" }
+  let(:auth_key_without_permission_name) { "badkey" }
 
   before do
-    Gemstash::Authorization.authorize(auth_key, "all")
-    Gemstash::Authorization.authorize(auth_key_without_permission, ["push"])
+    Gemstash::Authorization.authorize(auth_key, "all", auth_key_name)
+    Gemstash::Authorization.authorize(auth_key_without_permission, ["push"], auth_key_without_permission_name)
   end
 
   context "with no private gems" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -7,6 +7,7 @@ require "uri"
 describe "gemstash integration tests" do
   let(:auth) { Gemstash::ApiKeyAuthorization.new(auth_key) }
   let(:auth_key) { "test-key" }
+  let(:auth_key_name) { "somekey" }
 
   before(:all) do
     speaker_deps = [
@@ -106,7 +107,7 @@ describe "gemstash integration tests" do
 
     before do
       FileUtils.chmod(0600, File.join(env_dir, ".gem/credentials"))
-      Gemstash::Authorization.authorize(auth_key, "all")
+      Gemstash::Authorization.authorize(auth_key, "all", auth_key_name)
     end
 
     after do
@@ -280,7 +281,7 @@ describe "gemstash integration tests" do
 
     context "with private gems", db_transaction: false do
       before do
-        Gemstash::Authorization.authorize(auth_key, "all")
+        Gemstash::Authorization.authorize(auth_key, "all", auth_key_name)
         Gemstash::GemPusher.new(auth, read_gem("speaker", "0.1.0")).serve
         Gemstash::GemPusher.new(auth, read_gem("speaker", "0.1.0", platform: "java")).serve
         Gemstash::GemPusher.new(auth, read_gem("speaker", "0.2.0.pre")).serve


### PR DESCRIPTION
To allow a unique text description stored against each auth key in the database.

Please review the Sequel migration to ensure I didn't bust anything obvious, otherwise I think it's relatively sane. Feel free to nitpick for cleanup items before a merge.