### PR TITLE
Fix various rubocop/codeclimate issues

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,7 +11,7 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
-    # Avaiable channels: https://docs.codeclimate.com/docs/rubocop
+    # Available channels: https://docs.codeclimate.com/docs/rubocop
     channel: "rubocop-0-67"
 
 exclude_patterns:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,16 +1,19 @@
 ---
-engines:
+version: "2"
+
+plugins:
   duplication:
     enabled: true
     config:
       languages:
-      - ruby
+        - ruby
   fixme:
     enabled: true
   rubocop:
     enabled: true
-ratings:
-  paths:
-  - "**.rb"
-exclude_paths:
-- spec/
+    # Avaiable channels: https://docs.codeclimate.com/docs/rubocop
+    channel: "rubocop-0-67"
+
+exclude_patterns:
+  - vendor/
+  - '*.log'

--- a/.rubocop-bundler.yml
+++ b/.rubocop-bundler.yml
@@ -60,6 +60,7 @@ Style/TrailingCommaInHashLiteral:
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
@@ -88,9 +89,6 @@ Style/EachWithObject:
   Enabled: false
 
 Style/SpecialGlobalVars:
-  Enabled: false
-
-Style/TrailingCommaInArguments:
   Enabled: false
 
 Naming/VariableNumber:

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -59,7 +59,7 @@ you push your own private gems as well."
   spec.add_development_dependency "rack-test", "~> 1.1"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.3"
-  # Use the latest version codeclimate support
+  # Use the latest version codeclimate supports which is 0.67.2 right now
   # This should match with the version in .codeclimate.yml
   spec.add_development_dependency "rubocop", "= 0.67.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.1.0"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -59,6 +59,8 @@ you push your own private gems as well."
   spec.add_development_dependency "rack-test", "~> 1.1"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "= 0.70.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.1"
+  # Use the latest version codeclimate support
+  # This should match with the version in .codeclimate.yml
+  spec.add_development_dependency "rubocop", "= 0.67.2"
+  spec.add_development_dependency "rubocop-performance", "~> 1.1.0"
 end

--- a/lib/gemstash/gem_source.rb
+++ b/lib/gemstash/gem_source.rb
@@ -29,7 +29,7 @@ module Gemstash
       include Gemstash::Logging
 
       def_delegators :@app, :cache_control, :content_type, :env, :halt,
-                     :headers, :http_client_for, :params, :redirect, :request
+        :headers, :http_client_for, :params, :redirect, :request
 
       def initialize(app)
         @app = app

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Gemstash::HTTPClient do
       context "with a client that specifies a user agent" do
         let(:http_client) do
           Gemstash::HTTPClient.new(faraday_client,
-                                   user_agent: "my-agent 6.6.6")
+            user_agent: "my-agent 6.6.6")
         end
 
         it "forwards the user agent to the remote server" do

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Gemstash::Upstream do
 
   it "supports getting user agent" do
     expect(Gemstash::Upstream.new("https://rubygems.org/",
-                                  user_agent: "my_user_agent").user_agent).to eq("my_user_agent")
+      user_agent: "my_user_agent").user_agent).to eq("my_user_agent")
   end
 
   describe ".url" do


### PR DESCRIPTION
This should fix the following issue at https://codeclimate.com/github/bundler/gemstash/builds/115
```
/usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:122:in `require': cannot load such file -- rubocop-performance (LoadError)
	from /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:122:in `require'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/config_loader_resolver.rb:15:in `block in resolve_requires'
```