### PR TITLE
Fix some broken links in readme

### DIFF
--- a/docs/gemstash-multiple-sources.7.md
+++ b/docs/gemstash-multiple-sources.7.md
@@ -9,10 +9,10 @@ stashed within your Gemstash server.
 ## Default Source
 
 When you don’t provide an explicit source (as with the [Quickstart
-Guide](gemstash-readme.7.md#quickstart-guide)), your gems will be
-fetched from https://rubygems.org. This default source is not set in
-stone. To change it, you need only edit the Gemstash configuration found
-at `~/.gemstash/config.yml`:
+Guide](../readme.md#quickstart-guide)), your gems will be fetched from
+https://rubygems.org. This default source is not set in stone. To change
+it, you need only edit the Gemstash configuration found at
+`~/.gemstash/config.yml`:
 
 ``` yaml
 # ~/.gemstash/config.yml

--- a/docs/gemstash-private-gems.7.md
+++ b/docs/gemstash-private-gems.7.md
@@ -4,9 +4,9 @@
 
 Stashing private gems in your Gemstash server requires a bit of
 additional setup. If you haven’t read through the [Quickstart
-Guide](gemstash-readme.7.md#quickstart-guide), you should do that first.
-By the end of this guide, you will be able to interact with your
-Gemstash server to store and retrieve your private gems.
+Guide](../readme.md#quickstart-guide), you should do that first. By the
+end of this guide, you will be able to interact with your Gemstash
+server to store and retrieve your private gems.
 
 ## Authorizing
 

--- a/man/gemstash-multiple-sources.7.md
+++ b/man/gemstash-multiple-sources.7.md
@@ -73,4 +73,4 @@ to the provided URL. Redirected calls like this will not be cached by Gemstash,
 and gem files will not be stashed, even if they were previously cached or
 stashed from the same gem source.
 
-[README_QUICKSTART]: ./gemstash-readme.7.md#quickstart-guide
+[README_QUICKSTART]: ../readme.md#quickstart-guide

--- a/man/gemstash-private-gems.7.md
+++ b/man/gemstash-private-gems.7.md
@@ -170,5 +170,5 @@ Behind the scene, Bundler will pick up the ENV var according to the host name
 The API key is treated as a HTTP Basic Auth username and any HTTP Basic password
 supplied will be ignored.
 
-[README_QUICKSTART]: ./gemstash-readme.7.md#quickstart-guide
+[README_QUICKSTART]: ../readme.md#quickstart-guide
 [CONFIG_KEYS]: http://bundler.io/man/bundle-config.1.html#CONFIGURATION-KEYS


### PR DESCRIPTION
The Gemstash README.md includes a section titled [Deep Dive](https://github.com/rubygems/gemstash#deep-dive) that includes topics for further reading. Two of those topics, "Private Gems" and "Multiple Gem Sources", have their own README.md files. In those
READMEs is a broken link to the Gemstash's Quickstart section. This commit fixes that.

I did this by updating the specific `man` files and then I ran `rake doc`. This kicked off a task to update the corresponding files in the `docs` directory. 