### PR TITLE
Add puma server pidfile configuration option

### DIFF
--- a/bin/gemstash
+++ b/bin/gemstash
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 require "bundler/setup"
-exec "exe/gemstash", *ARGV
+require "gemstash/cli"
+Gemstash::CLI.start

--- a/lib/gemstash/cli/base.rb
+++ b/lib/gemstash/cli/base.rb
@@ -47,7 +47,7 @@ module Gemstash
       end
 
       def pidfile_args
-        ["--pidfile", gemstash_env.base_file("puma.pid")]
+        ["--pidfile", gemstash_env.pidfile]
       end
     end
   end

--- a/lib/gemstash/env.rb
+++ b/lib/gemstash/env.rb
@@ -6,6 +6,7 @@ require "dalli"
 require "fileutils"
 require "sequel"
 require "uri"
+require "pathname"
 
 module Gemstash
   # Storage for application-wide variables and configuration.
@@ -106,6 +107,19 @@ module Gemstash
         $stdout
       else
         base_file(config[:log_file] || "server.log")
+      end
+    end
+
+    def pidfile
+      if config[:pidfile]
+        pathname = Pathname.new(config[:pidfile])
+        if pathname.relative?
+          base_file(pathname.to_s)
+        else
+          pathname.to_s
+        end
+      else
+        base_file("puma.pid")
       end
     end
 

--- a/spec/gemstash/env_spec.rb
+++ b/spec/gemstash/env_spec.rb
@@ -25,6 +25,28 @@ RSpec.describe Gemstash::Env do
     end
   end
 
+  context ".pidfile" do
+    let(:dir) { __dir__ }
+
+    it "has default pidfile path" do
+      config = Gemstash::Configuration.new(config: { base_path: dir })
+      env = Gemstash::Env.new(config)
+      expect(env.pidfile).to eq(File.join(dir, "puma.pid"))
+    end
+
+    it "supports relative path" do
+      config = Gemstash::Configuration.new(config: { base_path: dir, pidfile: "custom/puma.pid" })
+      env = Gemstash::Env.new(config)
+      expect(env.pidfile).to eq(File.join(dir, "custom", "puma.pid"))
+    end
+
+    it "supports absolute path" do
+      config = Gemstash::Configuration.new(config: { base_path: dir, pidfile: "/var/run/gemstash.pid" })
+      env = Gemstash::Env.new(config)
+      expect(env.pidfile).to eq("/var/run/gemstash.pid")
+    end
+  end
+
   context "with a base path other than default" do
     let(:env) { Gemstash::Env.new }
 


### PR DESCRIPTION
It would be useful to allow setting up custom puma pidfile locations. For example you might want to set it to `/var/run/gemstash-puma.pid` so that the file does not persist in case of system is not shut down correctly.