### PR TITLE
Officially drop support for older rubies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,4 @@ AllCops:
     - vendor/**/*
     - gemfiles/**/*
   DisplayCopNames: true
+  TargetRubyVersion: 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,4 @@
 
 source "https://rubygems.org"
 
-# Declare Ruby version so that activesupport gem can notice that
-ruby RUBY_VERSION
-
 gemspec

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -29,6 +29,8 @@ you push your own private gems as well."
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.4"
+
   spec.add_runtime_dependency "activesupport", ">= 4.2", "< 6"
   spec.add_runtime_dependency "dalli", "~> 2.7"
   spec.add_runtime_dependency "faraday", "~> 0.9"


### PR DESCRIPTION
In https://github.com/rubygems/gemstash/pull/198 it was discussed to drop support for old rubies, and then testing against those rubies stopped at https://github.com/rubygems/gemstash/pull/201. But support was not actually dropped in the sense that the gem still installs in old rubies. It might be already broken though since they haven't been tested for a while.

Anyways, this PR should prevent installation on those no longer supported rubies.