### PR TITLE
Add config to ignore Gemfile source

### DIFF
--- a/docs/gemstash-configuration.5.md
+++ b/docs/gemstash-configuration.5.md
@@ -149,6 +149,20 @@ already gems stashed for the previous value.
 
 A valid gem source URL
 
+# Ignore Gemfile source
+
+`:ignore_gemfile_source`
+
+Ignore the source specified in Gemfile and always use `:rubygems_url` as gems upstream.
+
+## Default value
+
+`false`
+
+## Valid values
+
+Boolean: `true` or `false`
+
 # Puma Threads
 
 `:puma_threads`

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -12,6 +12,7 @@ module Gemstash
       db_adapter: "sqlite3",
       bind: "tcp://0.0.0.0:9292",
       rubygems_url: "https://rubygems.org",
+      ignore_gemfile_source: false,
       protected_fetch: false,
       fetch_timeout: 20,
       # Actual default for db_connection_options is dynamic based on the adapter

--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -198,7 +198,7 @@ module Gemstash
     # default upstream).
     class RubygemsSource < Gemstash::GemSource::UpstreamSource
       def self.matches?(env)
-        env["gemstash.upstream"] = if env["HTTP_X_GEMFILE_SOURCE"].to_s.empty?
+        env["gemstash.upstream"] = if env["gemstash.env"].config[:ignore_gemfile_source] || env["HTTP_X_GEMFILE_SOURCE"].to_s.empty?
           env["gemstash.env"].config[:rubygems_url]
         else
           env["HTTP_X_GEMFILE_SOURCE"]

--- a/man/gemstash-configuration.5.md
+++ b/man/gemstash-configuration.5.md
@@ -22,6 +22,7 @@ gemstash-configuration
   :test: true
   :pool_timeout: 2
 :rubygems_url: https://my.gem-source.local
+:ignore_gemfile_source: false
 :puma_threads: 32
 :bind: tcp://0.0.0.0:4242
 :protected_fetch: true
@@ -146,6 +147,20 @@ for the previous value.
 ## Valid values
 
 A valid gem source URL
+
+# Ignore Gemfile source
+
+`:ignore_gemfile_source`
+
+Ignore the source specified in Gemfile and always use `:rubygems_url` as gems upstream.
+
+## Default value
+
+`false`
+
+## Valid values
+
+Boolean: `true` or `false`
 
 # Puma Threads
 


### PR DESCRIPTION
This PR adds `:ignore_gemfile_source` config to ignore source specified in Gemfile and always use `:rubygems_url` as gems upstream.

Valid config values: `true` or `false`.

This change allows Gemstash to use a Bundler mirror site for fetching remote gems, instead of fetching from Gemfile source. 

Related Issue: #252 