### PR TITLE
Require Redis only if it gets initialized

### DIFF
--- a/lib/gemstash/cache.rb
+++ b/lib/gemstash/cache.rb
@@ -2,7 +2,6 @@
 
 require "lru_redux"
 require "forwardable"
-require "redis"
 
 module Gemstash
   # Cache object which knows about what things are cached and what keys to use
@@ -88,6 +87,7 @@ module Gemstash
     def_delegator :@cache, :del, :delete
 
     def initialize(redis_servers)
+      require "redis"
       @cache = ::Redis.new(:url => redis_servers)
     end
 


### PR DESCRIPTION
# Description

Fix issue with LoadError 'redis' when not being used

______________

# Tasks:

-  The changes in 808c034e5f3a3a40bf99f53ac398520fd3774e0f removed a runtime dependency on Redis, but still tries to import it in lib/gemstash/cache.rb, which will trigger an error for configurations that aren't using Redis.  Moving it within the initialize block so that it only gets loaded if this class that encapsulates this behavior is used.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
