### PR TITLE
Add "require forwardable" for Upstream

### DIFF
--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "digest"
+require "forwardable"
 require "uri"
 
 module Gemstash


### PR DESCRIPTION
# Description:
We ran into this because we have a separate process to clear the spec files that uses the "Upstream" model, and without this change we were seeing the following error:
```
/lib/gemstash/upstream.rb:9:in `<class:Upstream>': uninitialized constant Gemstash::Upstream::Forwardable (NameError)
```
______________

# Tasks:
When you "extend Forwardable", it "[requires forwardable](https://rub…y-doc.org/stdlib-2.5.1/libdoc/forwardable/rdoc/Forwardable.html)". Currently, in Gemstash it is getting that library via a different route for "Upstream".

It feels more explicit to get "Forwardable" from "require forwardable", and we follow the pattern in [all other models](https://github.com/rubygems/gemstash/search?q=forwardable&unscoped_q=forwardable) except "Upstream".

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
