### PR TITLE
Introducing Gemstash Info Command

### DIFF
--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -13,6 +13,7 @@ module Gemstash
     autoload :Start,     "gemstash/cli/start"
     autoload :Status,    "gemstash/cli/status"
     autoload :Stop,      "gemstash/cli/stop"
+    autoload :Info,      "gemstash/cli/info"
 
     # Thor::Error for the CLI, which colors the message red.
     class Error < Thor::Error
@@ -98,6 +99,11 @@ module Gemstash
       say "Gemstash version #{Gemstash::VERSION}"
     end
     map %w[-v --version] => :version
+
+    desc "info", "Check current gemstash instance info"
+    def info
+      Gemstash::CLI::Info.new(self).run
+    end
 
   private
 

--- a/lib/gemstash/cli/info.rb
+++ b/lib/gemstash/cli/info.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "gemstash"
+require "puma/control_cli"
+
+module Gemstash
+  class CLI
+    class Info < Gemstash::CLI::Base
+      include Gemstash::Env::Helper
+      def run
+        prepare
+        list_config
+      end
+
+    private
+
+      def list_config
+        @config = parse_config(config_file)
+        @config = Gemstash::Configuration::DEFAULTS.merge(@config)
+        @config.map do |key, _value|
+          @cli.say "#{key}: #{gemstash_env.config[key]}"
+        end
+      end
+
+      def config_file
+        @cli.options[:config_file] || Gemstash::Configuration::DEFAULT_FILE
+      end
+
+      def parse_config(file)
+        if file.end_with?(".erb")
+          YAML.load(ERB.new(File.read(file)).result) || {}
+        else
+          YAML.load_file(file) || {}
+        end
+      end
+    end
+  end
+end

--- a/lib/gemstash/cli/info.rb
+++ b/lib/gemstash/cli/info.rb
@@ -5,6 +5,8 @@ require "puma/control_cli"
 
 module Gemstash
   class CLI
+    # This implements the command line setup task:
+    #  $ gemstash info
     class Info < Gemstash::CLI::Base
       include Gemstash::Env::Helper
       def run
@@ -15,22 +17,9 @@ module Gemstash
     private
 
       def list_config
-        @config = parse_config(config_file)
-        @config = Gemstash::Configuration::DEFAULTS.merge(@config)
-        @config.map do |key, _value|
-          @cli.say "#{key}: #{gemstash_env.config[key]}"
-        end
-      end
-
-      def config_file
-        @cli.options[:config_file] || Gemstash::Configuration::DEFAULT_FILE
-      end
-
-      def parse_config(file)
-        if file.end_with?(".erb")
-          YAML.load(ERB.new(File.read(file)).result) || {}
-        else
-          YAML.load_file(file) || {}
+        @config = gemstash_env.config
+        @config.keys.map do |key|
+          @cli.say "#{key}: #{@config[key]}"
         end
       end
     end

--- a/lib/gemstash/cli/info.rb
+++ b/lib/gemstash/cli/info.rb
@@ -5,7 +5,7 @@ require "puma/control_cli"
 
 module Gemstash
   class CLI
-    # This implements the command line setup task:
+    # This implements the command line info task:
     #  $ gemstash info
     class Info < Gemstash::CLI::Base
       include Gemstash::Env::Helper

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -60,6 +60,10 @@ module Gemstash
       @config[key]
     end
 
+    def keys
+      @config.keys
+    end
+
     # @return [Hash] Sequel connection configuration hash
     def database_connection_config
       case self[:db_adapter]

--- a/spec/gemstash/cli/info_spec.rb
+++ b/spec/gemstash/cli/info_spec.rb
@@ -4,22 +4,38 @@ require "spec_helper"
 
 RSpec.describe Gemstash::CLI::Info do
   let(:defaults) do
-    default = ""
-    Gemstash::Configuration::DEFAULTS.map do |key, value|
-      default << "#{key}: #{value}" << "\n"
-    end
-    default
+    <<~DEFAULT
+      cache_type: memory
+      base_path: #{File.expand_path("~/.gemstash")}
+      db_adapter: sqlite3
+      bind: tcp://0.0.0.0:9292
+      rubygems_url: https://rubygems.org
+      ignore_gemfile_source: false
+      protected_fetch: false
+      fetch_timeout: 20
+      db_connection_options: {}
+      puma_threads: 16
+      puma_workers: 1
+      cache_expiration: 1800
+      cache_max_size: 500
+    DEFAULT
   end
   let(:with_protected_fetch_true) do
-    default = ""
-    Gemstash::Configuration::DEFAULTS.map do |key, value|
-      if key == :protected_fetch
-        default << "#{key}: true" << "\n"
-      else
-        default << "#{key}: #{value}" << "\n"
-      end
-    end
-    default
+    <<~DEFAULT
+      cache_type: memory
+      base_path: #{File.expand_path("~/.gemstash")}
+      db_adapter: sqlite3
+      bind: tcp://0.0.0.0:9292
+      rubygems_url: https://rubygems.org
+      ignore_gemfile_source: false
+      protected_fetch: true
+      fetch_timeout: 20
+      db_connection_options: {}
+      puma_threads: 16
+      puma_workers: 1
+      cache_expiration: 1800
+      cache_max_size: 500
+    DEFAULT
   end
   let(:cli) do
     result = double(options: cli_options)

--- a/spec/gemstash/cli/info_spec.rb
+++ b/spec/gemstash/cli/info_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Gemstash::CLI::Info do
+  let(:defaults) do
+    default = ""
+    Gemstash::Configuration::DEFAULTS.map do |key, value|
+      default << "#{key}: #{value}" << "\n"
+    end
+    default
+  end
+  let(:with_protected_fetch_true) do
+    default = ""
+    Gemstash::Configuration::DEFAULTS.map do |key, value|
+      if key == :protected_fetch
+        default << "#{key}: true" << "\n"
+      else
+        default << "#{key}: #{value}" << "\n"
+      end
+    end
+    default
+  end
+  let(:cli) do
+    result = double(options: cli_options)
+    allow(result).to receive(:set_color) {|x| x }
+    result
+  end
+
+  let(:cli_options) do
+    {
+      config_file: File.join(TEST_BASE_PATH, "info_spec_config.yml")
+    }
+  end
+
+  context "with default setup" do
+    # Setup the environment with all default configurations
+    before do
+      allow(cli).to receive(:ask).and_return("")
+      allow(cli).to receive(:yes?).and_return("")
+      expect(File.exist?(cli_options[:config_file])).to be_falsey
+      # This is expected to touch the metadata file, which we don't want to
+      # write out (it would go in ~/.gemstash rather than our test path)
+      expect(Gemstash::Storage).to receive(:metadata)
+      allow(cli).to receive(:say)
+      Gemstash::CLI::Setup.new(cli).run
+      expect(File.exist?(cli_options[:config_file])).to be_truthy
+    end
+
+    it "saves the config with defaults, then printing only default configs" do
+      allow(Gemstash::Storage).to receive(:metadata).and_return(gemstash_version: "1.0.0")
+      stub_const("Gemstash::VERSION", "1.0.0")
+      allow(cli).to receive(:say).with(anything) do |value|
+        STDOUT.write value + "\n"
+        STDOUT.flush
+      end
+      expect(File.exist?(cli_options[:config_file])).to be_truthy
+      expect { Gemstash::CLI::Info.new(cli).run }.to output(defaults).to_stdout_from_any_process
+    end
+  end
+  context "with manual change in setup" do
+    # Setup the environment with protected fetching set to false
+    before do
+      allow(cli).to receive(:ask).and_return("")
+      allow(cli).to receive(:yes?).and_return("")
+      allow(cli).to receive(:yes?).with("Use Protected Fetch for Private Gems? [y/N]").and_return("true")
+      expect(File.exist?(cli_options[:config_file])).to be_falsey
+      # This is expected to touch the metadata file, which we don't want to
+      # write out (it would go in ~/.gemstash rather than our test path)
+      expect(Gemstash::Storage).to receive(:metadata)
+      allow(cli).to receive(:say)
+      allow(cli).to receive(:options).with(:redo).and_return(true)
+      Gemstash::CLI::Setup.new(cli).run
+      expect(File.exist?(cli_options[:config_file])).to be_truthy
+    end
+    it "saves the config, then printing config with protect fetch sets to true" do
+      allow(Gemstash::Storage).to receive(:metadata).and_return(gemstash_version: "1.0.0")
+      stub_const("Gemstash::VERSION", "1.0.0")
+      allow(cli).to receive(:say).with(anything) do |value|
+        STDOUT.write value + "\n"
+        STDOUT.flush
+      end
+      expect { Gemstash::CLI::Info.new(cli).run }.to_not output(defaults).to_stdout_from_any_process
+      expect { Gemstash::CLI::Info.new(cli).run }.to output(with_protected_fetch_true).to_stdout_from_any_process
+    end
+  end
+end


### PR DESCRIPTION
# Description:
A simple "quality of life" change to gemstash. 
If you type the command
```
gemstash info
```
It will return the current configurations settings of gemstash. This is useful because it was difficult to check what was changed in the gemstash configuration during setup. Let's say you decided to change to use memcached instead of memory caching, it was difficult to check what was in the current setup afterward. This command will allow you to do so.
In addition, it will be useful for #270 to check if the credentials were provided correctly.
______________

# Tasks:

-  Write tests for the command

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
