### PR TITLE
smaller fetch_timeout value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
   include:
-    - rvm: 2.4.7
-    - rvm: 2.5.6
-    - rvm: 2.6.4
+    - rvm: 2.6.6
+    - rvm: 2.7.2
     - rvm: ruby-head
       gemfile: 'gemfiles/Gemfile.ruby-head'
 

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Gemstash::HTTPClient do
       end
 
       it "times out with a small fetch_timeout value" do
-        config = Gemstash::Configuration.new(config: { fetch_timeout: 0.1 })
+        config = Gemstash::Configuration.new(config: { fetch_timeout: 0.05 })
         Gemstash::Env.current = Gemstash::Env.new(config)
         client = Gemstash::HTTPClient.for(Gemstash::Upstream.new(@slow_server.url))
         expect do


### PR DESCRIPTION
It should stabilize the test.

But first the following MR should be `git reset --hard`:

* https://github.com/rubygems/gemstash/commit/872ccae8e3abb65a226e3d33715865c2fa6b1beb
* https://github.com/rubygems/gemstash/commit/58437b71f5d6785f4bc1ebe3c75042c245ae4298

# Description:

______________

# Tasks:

-  The tests were not stable on Ubuntu with ruby 2.7.
-  I reduced the fetch_timeout of a test and it should stabilize the whole tests suite on ruby 2.7 and Ubuntu.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
