### PR TITLE
fix: add psych runtime dependency

### DIFF
--- a/lib/gemstash/storage.rb
+++ b/lib/gemstash/storage.rb
@@ -68,7 +68,7 @@ module Gemstash
         end
       end
 
-      YAML.load_file(file)
+      YAML.safe_load_file(file, permitted_classes: [Symbol])
     end
 
   private
@@ -280,7 +280,7 @@ module Gemstash
       return if @properties && !force
       return unless File.exist?(properties_filename)
 
-      @properties = YAML.load_file(properties_filename) || {}
+      @properties = YAML.safe_load_file(properties_filename, permitted_classes: [Symbol]) || {}
       check_resource_version
     end
 


### PR DESCRIPTION
`gemstash` does not support psych >= 4.0, the PR fixed this by using a compatible interface for both psych v3 and v4.

bug reproduction:

```sh
docker run --rm -i -v $(pwd):/src -w /src ruby:2.7-alpine sh -s <<EOS
apk add gcc make musl-dev sqlite-dev git &&
  gem install bundler:1.17.3 &&
  bundle _1.17.3_ &&
  bin/gemstash start --no-daemonize
EOS
```

output:

```
/usr/local/bundle/gems/psych-4.0.0/lib/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Symbol (Psych::DisallowedClass)
```

## Overview

For psych v4, we neeed to add `permitted_classes` keyword argument:

```rb
YAML.load_file(file, permitted_classes: [Symbol])
```

For psych v3, `YAML#load_file` doesn't support `permitted_classes`, we
need to use `YAML#safe_load_file`:

```rb
YAML.safe_load_file(file, permitted_classes: [Symbol])
```

Thus, to support both psych v3, and v4, the final form would be:

```rb
YAML.safe_load_file(file, permitted_classes: [Symbol])
```
