### PR TITLE
Update gemstash-customize.7.md

### DIFF
--- a/docs/gemstash-customize.7.md
+++ b/docs/gemstash-customize.7.md
@@ -166,7 +166,7 @@ configuration key.
 ```
 
 More details on [protected\_fetch are
-here](docs/gemstash-private-gems.7.md#protected-fetching).
+here](gemstash-private-gems.7.md#protected-fetching).
 
 ## Fetch Timeout
 


### PR DESCRIPTION
fix broken link

It doesn't work while browsing github. But I'm not sure if this is not introducing any problems for generated man pages.