### PR TITLE
ci: fix ci for cruby platforms

### DIFF
--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -17,6 +17,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
           wait-on: tcp://0.0.0.0:9041, tcp://0.0.0.0:9042, tcp://0.0.0.0:9043, tcp://0.0.0.0:9044
+      - name: Update rubygems
+        run: gem update --system
       - name: increase ulimit
         run: ulimit -n 8192
       - name: Install Dependencies

--- a/bin/setup
+++ b/bin/setup
@@ -2,4 +2,4 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-bundle install
+bundle _1.17.3_ install

--- a/spec/support/exec_helpers.rb
+++ b/spec/support/exec_helpers.rb
@@ -29,7 +29,7 @@ module ExecHelpers
     end
 
     def exec
-      @output, @status = Open3.capture2e(patched_env, command, *args, chdir: dir)
+      @output, @status = Open3.capture2(patched_env, command, *args, chdir: dir)
     end
 
     def successful?


### PR DESCRIPTION
CI  result: https://github.com/tonytonyjan/gemstash/actions/runs/1433599818

This change tends to use the most compatible way to make CI work again without changing any dependency like `psych` or `bundler` but only updates Rubygems by `gem update --system`.

The CI fails Ruby v2.4.7 and v2.5.6 because old Rubygems does not support latest psych:

```
Failures:

  1) Gemstash::GemPusher.serve with an unknown gem name saves the dependency info and stores the gem
     Failure/Error: @full_name ||= gem.spec.full_name

     ArgumentError:
       wrong number of arguments (given 4, expected 1)
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/gems/2.5.0/gems/psych-4.0.2/lib/psych.rb:323:in `safe_load'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/safe_yaml.rb:31:in `safe_load'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:496:in `block (2 levels) in read_checksums'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:495:in `wrap'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:495:in `block in read_checksums'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package/tar_reader.rb:116:in `seek'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:494:in `read_checksums'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:547:in `block (2 levels) in verify'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package/tar_reader.rb:29:in `new'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:546:in `block in verify'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package/io_source.rb:35:in `with_read_io'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:545:in `verify'
     # /opt/hostedtoolcache/Ruby/2.5.6/x64/lib/ruby/2.5.0/rubygems/package.rb:526:in `spec'
     # ./lib/gemstash/gem_pusher.rb:50:in `full_name'
```

Newer Rubygems has fixed `psych` by [the commit](https://github.com/rubygems/rubygems/commit/b7995ca4ea8452b4511f4afa7eddd5374fca21fc#diff-5f082f8e57fcf70e33adc52897d656b3b8273bbf24220f21ede654fe456454c1), thus running `gem update --system` should solve the problem but it derives 2 issues:

1. `gem update --system` also updates `bundler` to the latest version that breaks `bin/setup` because there is no `Gemfile.lock` at the beginning which causes `bundler` couldn't know which version to use.

   We can solve the issue by adding `bundle _1.17.3_` to `bin/setup`.

2. Newer Rubygems deprecated the constant `Gem::ConfigMap` by [this commit](https://github.com/rubygems/rubygems/commit/1133c2f70075bef3cab954b128857c9e81e03124), thus it would print warning messages to standard error, for example:

   ```
   Failures:

   1) gemstash integration tests bundle install against gemstash with default upstream gems behaves like a bundleable project successfully bundles
       Failure/Error:
       expect(execute("bundle", %w[exec speaker hi], dir: dir, env: env)).
           to exit_success.and_output("Hello world, #{platform_message}\n")

       expected 'bundle exec speaker hi' in '/home/runner/work/gemstash/gemstash/spec/data/bundles/integration_spec/default_upstream_gems' to output:
       Hello world, Ruby

       but instead it output:
       /opt/hostedtoolcache/Ruby/2.4.7/x64/lib/ruby/gems/2.4.0/gems/bundler-1.17.3/lib/bundler/rubygems_integration.rb:200: warning: constant Gem::ConfigMap is deprecated
       Hello world, Ruby
   ```

   We can solve the issue by either decrease Ruby warning level or replacing `Open3.capture2e` with `Open3.capture2`. Here we use the latter solution because the former is a little overkill and writing tests for standard error output makes little sense.