### PR TITLE
CI: Lint job use Ruby "2.6"; drop unused config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.4
+        ruby-version: 2.6
         bundler: none
-        bundler-cache: true
-
     - name: Install Dependencies
       run: gem install bundler -v 1.17.3 && bin/setup
     - name: Rubocop


### PR DESCRIPTION

# Description:

The configuration option bundler-cache is only relevant when having a Bundler. We use "none", so there is no caching or "bundle install" happening in the ruby/setup-ruby Action.

