### PR TITLE
CI: Use major-minor ("2.4"-style) Ruby versions

### DIFF
--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4.7, 2.5.6, 2.6.4, jruby-9.2.9.0]
+        ruby: [2.4, 2.5, 2.6, jruby-9.2.20.0]
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby


### PR DESCRIPTION
# Description:

This PR changes the build matrix to use less-exact versions.

This allows us to rely on the patch version management of the well-maintained ruby/setup-ruby Action.

Here is how:
https://github.com/ruby/setup-ruby/blob/a2b2637a7c796d83d566fc82853156d4372b0f60/index.js#L119

The data used is here:
https://github.com/ruby/setup-ruby/blob/master/ruby-builder-versions.js
