### PR TITLE
CI: Add 2.7, add bundler-cache: true

### DIFF
--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
-      matrix: # Quote "3.0" to avoid 3.0 converted to "3"
-        ruby: [2.4, 2.5, 2.6, 2.7, "3.0", jruby-9.2]
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7, jruby-9.2]
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # 'bundle install' and cache
+      - run: gem update --system
+        if: "${{ matrix.ruby == '2.6' }}"
       - name: increase ulimit
         run: ulimit -n 8192
       - name: Run Tests

--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -7,21 +7,17 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
-      matrix:
-        ruby: [2.4, 2.5, 2.6, jruby-9.2.20.0]
+      matrix: # Quote "3.0" to avoid 3.0 converted to "3"
+        ruby: [2.6, 2.7, "3.0", jruby-9.2]
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: none
-      - name: Update rubygems
-        run: gem update --system
+          bundler-cache: true # 'bundle install' and cache
       - name: increase ulimit
         run: ulimit -n 8192
-      - name: Install Dependencies
-        run: gem install bundler -v 1.17.3 && bin/setup
       - name: Run Tests
         run: bundle exec rspec --exclude-pattern "spec/integration_spec.rb"
       - name: Run Integration Tests

--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # Quote "3.0" to avoid 3.0 converted to "3"
-        ruby: [2.6, 2.7, "3.0", jruby-9.2]
+        ruby: [2.4, 2.5, 2.6, 2.7, "3.0", jruby-9.2]
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
@@ -17,7 +17,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # 'bundle install' and cache
       - run: gem update --system
-        if: "${{ matrix.ruby == '2.6' }}"
+        if: "${{ matrix.ruby == '2.6' || matrix.ruby == '2.5' || matrix.ruby == '2.4' }}"
       - name: increase ulimit
         run: ulimit -n 8192
       - name: Run Tests

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "webrick" if RUBY_VERSION >= "3"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -56,7 +56,7 @@ you push your own private gems as well."
   end
 
   spec.add_development_dependency "aruba", [">= 0.14"]
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "citrus", "~> 3.0"
   spec.add_development_dependency "octokit", "~> 4.2"
   spec.add_development_dependency "pandoc_object_filters", "~> 0.2"


### PR DESCRIPTION
# Description:

This PR adds 2.7 to the matrix. And installation via the `bundler-cache: true` installation.

Background:

- Tried removing matrix elements
- Tried adding 3.0 - which is unsupported due to a Sinatra compat issue

