### PR TITLE
build: Try to use a Bundler group for lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,14 @@ jobs:
   rubocop:
     name: Rubocop
     runs-on: ubuntu-18.04
+    env:
+      BUNDLE_WITH: "linting"
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
-        bundler: none
-    - name: Install Dependencies
-      run: gem install bundler -v 1.17.3 && bin/setup
+        bundler-cache: true # 'bundle install' and cache
     - name: Rubocop
       run: bundle exec rubocop
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gemspec
 
+group :linting do
+  gem "rubocop", "= 0.67.2"
+  gem "rubocop-performance", "~> 1.1.0"
+end
+
 gem "webrick" if RUBY_VERSION >= "3"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -64,6 +64,4 @@ you push your own private gems as well."
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "redis", "~> 3.3"
   spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "= 0.67.2"
-  spec.add_development_dependency "rubocop-performance", "~> 1.1.0"
 end


### PR DESCRIPTION
# Description:

RuboCop in a Bundler group, and use caching.

Hm, this does not skip the installation of the other stuff, the group, as used here - BUT the bundler-cache _works_.

