### PR TITLE
Move development dependencies to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,14 @@
 source "https://rubygems.org"
 
 gemspec
+gem "aruba", ">= 0.14"
+gem "citrus", "~> 3.0"
+gem "octokit", "~> 4.2"
+gem "pandoc_object_filters", "~> 0.2"
+gem "rack-test", "~> 1.1"
+gem "rake", "~> 12.3"
+gem "redis", "~> 3.3"
+gem "rspec", "~> 3.3"
 
 group :linting do
   gem "rubocop", "= 0.67.2"

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -54,14 +54,4 @@ you push your own private gems as well."
   else
     spec.add_runtime_dependency "sqlite3", "~> 1.3"
   end
-
-  spec.add_development_dependency "aruba", [">= 0.14"]
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "citrus", "~> 3.0"
-  spec.add_development_dependency "octokit", "~> 4.2"
-  spec.add_development_dependency "pandoc_object_filters", "~> 0.2"
-  spec.add_development_dependency "rack-test", "~> 1.1"
-  spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "redis", "~> 3.3"
-  spec.add_development_dependency "rspec", "~> 3.3"
 end


### PR DESCRIPTION
# Description:

After moving the linting development dependencies into their own section in the Gemfile, there remained gemspec definitions of other development dependencies.

This PR moves them to the Gemfile, too.

See discussion in https://github.com/rubygems/gemstash/pull/309#issuecomment-964017330  and #302
