### PR TITLE
fix: Remove version pin to Bundler 1.x in script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,4 +2,4 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-bundle _1.17.3_ install
+bundle install


### PR DESCRIPTION


# Description:

This was necessary in a stage in-between CI changes, but no longer.
