### PR TITLE
Respect auth set in upstream host uri

### DIFF
--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -35,11 +35,16 @@ module Gemstash
         config.adapter :net_http
         config.options.timeout = gemstash_env.config[:fetch_timeout]
       end
+
+      client.basic_auth(upstream.user, upstream.password) if upstream.auth?
+
       user_agent = "#{upstream.user_agent} " unless upstream.user_agent.to_s.empty?
       user_agent = user_agent.to_s + DEFAULT_USER_AGENT
 
       new(client, user_agent: user_agent)
     end
+
+    attr_reader :client
 
     def initialize(client = nil, user_agent: nil)
       @client = client

--- a/lib/gemstash/upstream.rb
+++ b/lib/gemstash/upstream.rb
@@ -32,7 +32,7 @@ module Gemstash
     end
 
     def auth?
-      !user.to_s.empty? && !password.to_s.empty?
+      !user.to_s.empty? || !password.to_s.empty?
     end
 
     # Utilized as the parent directory for cached gems

--- a/spec/gemstash/http_client_spec.rb
+++ b/spec/gemstash/http_client_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe Gemstash::HTTPClient do
     @other_server.stop
   end
 
+  describe '#for' do
+    context 'when user:pass auth is in the upstream url' do
+      let(:upstream) { Gemstash::Upstream.new("https://username:password@localhost/") }
+      subject { Gemstash::HTTPClient.for(upstream).client.headers }
+      it { is_expected.to include("Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ=") }
+    end
+
+    context 'when api_key auth is in the upstream url' do
+      let(:upstream) { Gemstash::Upstream.new("https://api_key@localhost/") }
+      subject { Gemstash::HTTPClient.for(upstream).client.headers }
+      it { is_expected.to include("Authorization" => "Basic YXBpX2tleTo=") }
+    end
+
+    context 'when no auth is included in the upstream url' do
+      let(:upstream) { Gemstash::Upstream.new("https://localhost/") }
+      subject { Gemstash::HTTPClient.for(upstream).client.headers }
+      it { is_expected.to_not include("Authorization") }
+    end
+  end
+
   describe ".get" do
     let(:http_client) do
       Gemstash::HTTPClient.for(Gemstash::Upstream.new(@server.url))

--- a/spec/gemstash/upstream_spec.rb
+++ b/spec/gemstash/upstream_spec.rb
@@ -23,10 +23,18 @@ RSpec.describe Gemstash::Upstream do
     expect(upstream_uri.password).to be_nil
   end
 
-  it "supports url auth in the uri" do
+  it "supports user:pass url auth in the uri" do
     upstream_uri = Gemstash::Upstream.new("https://myuser:mypassword@rubygems.org/")
     expect(upstream_uri.user).to eq("myuser")
     expect(upstream_uri.password).to eq("mypassword")
+    expect(upstream_uri.auth?).to be_truthy
+  end
+
+  it "supports api_key url auth in the uri" do
+    upstream_uri = Gemstash::Upstream.new("https://api_key@rubygems.org/")
+    expect(upstream_uri.user).to eq("api_key")
+    expect(upstream_uri.password).to be_nil
+    expect(upstream_uri.auth?).to be_truthy
   end
 
   it "distinguishes between ports, auths, and paths" do


### PR DESCRIPTION
# Description:

Some private gem repos like [Gemfury](https://gemfury.io) use Basic Auth with just an api key rather than a username and password (ex. `https://<api_key>@gem.fury.io/<repo>`). Setting up upstream mirroring for this case should work as described in #247, but because `Faraday` does not respect Basic Authentication being passed in the URL unless its of the `user:pass` format, some additional logic was needed to support this use case.

______________

# Tasks:

-  Describe the problem / feature
-  Write tests

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
