### PR TITLE
Change the response code for "/versions" from 403 to 404

### DIFF
--- a/lib/gemstash/gem_source/private_source.rb
+++ b/lib/gemstash/gem_source/private_source.rb
@@ -47,7 +47,7 @@ module Gemstash
       end
 
       def serve_versions
-        halt 403, "Not yet supported"
+        halt 404, "Not yet supported"
       end
 
       def serve_info(name)


### PR DESCRIPTION
This allows to use Renovate with Gemstash.
Renovate changed their update logic to use the `/versions` endpoint, breaking the compatibility with Gemstash.
However the old logic is still used as a fallback in case the endpoint returns a 404.

Related PR: https://github.com/renovatebot/renovate/pull/16312
