### PR TITLE
Add .rake_github_token to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.rake_github_token


### PR DESCRIPTION
# Description:

This PR git-ignores a file which can contain credentials.

The token file is used when releasing, to regenerate the CHANGELOG.md file, using a rake task "changelog".

Unrelated to this change: When I ran that task today, it failed, with a rate-limiting error, and I was unable to update the file.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
