### PR TITLE
Make UpstreamSource intermediate specs from upstream

### DIFF
--- a/lib/gemstash/gem_source/upstream_source.rb
+++ b/lib/gemstash/gem_source/upstream_source.rb
@@ -128,6 +128,21 @@ module Gemstash
         serve_cached(id, :gem)
       end
 
+      def serve_latest_specs
+        http_client = http_client_for(upstream)
+        http_client.get("latest_specs.4.8.gz")
+      end
+
+      def serve_prerelease_specs
+        http_client = http_client_for(upstream)
+        http_client.get("prerelease_specs.4.8.gz")
+      end
+
+      def serve_specs
+        http_client = http_client_for(upstream)
+        http_client.get("specs.4.8.gz")
+      end
+      
     private
 
       def serve_cached(id, resource_type)


### PR DESCRIPTION
As discovered in #336, the retirement of the v1 dependencies API revealed that UpstreamSource, when the dependencies API is unavailable, tells the client to go talk to rubygems directly for the spec files. This model does not work in general, because there is no guarantee that the client can access rubygems directly. This commit changes UpstreamSource to intermediate the connection

# Description:

______________

# Tasks:

-  Describe the problem / feature
-  Write tests

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
