### PR TITLE
fix: Define 'sync' method on logger for compatibility with Puma > 5

### DIFF
--- a/lib/gemstash/logging.rb
+++ b/lib/gemstash/logging.rb
@@ -88,6 +88,10 @@ module Gemstash
 
       def sync=(_value); end
 
+      def sync
+        false
+      end
+
       def write(message)
         Gemstash::Logging.logger.add(@level, message)
       end


### PR DESCRIPTION
# Description:

Since at least https://github.com/puma/puma/commit/a284179d9d13c15e7b1f03332c3d2591bcd7d77b, puma has required that the logger respond to a `sync` method.

This implements the above method. With this change, Gemstash will start with Puma 6.3.1 when the `--no-daemonize` flag is passed.

It might also be worth changing the `daemonize` default to `false` - Puma versions greater than ~5.0 do not support demonizing (without https://github.com/kigster/puma-daemon or alternative)?

______________

# Tasks:

-  Describe the problem / feature
-  Write tests

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
