### PR TITLE
Add a missing Puma 6 require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+https://github.com/rubygems/gemstash/compare/v2.3.1...main
+
+### Fixes
+
+- Require a now-needed file for Puma 6. Thanks, [@ktreis][]! ([#362](https://github.com/rubygems/gemstash/pull/362), [@olleolleolle][])
+
 ## 2.3.1 (2023-09-05)
 
 https://github.com/rubygems/gemstash/compare/v2.3.0...v2.3.1
@@ -295,3 +303,4 @@ Also thanks to: [@indirect][] and [@hsbt][] who fixed CI issues and lint warning
 [@adarsh]: https://github.com/adarsh
 [@olleolleolle]: https://github.com/olleolleolle
 [@ball-hayden]: https://github.com/ball-hayden
+[@ktreis]: https://github.com/ktreis

--- a/lib/gemstash/logging.rb
+++ b/lib/gemstash/logging.rb
@@ -3,6 +3,7 @@
 require "logger"
 
 begin
+  require "puma/detect"
   require "puma/log_writer" # Puma 6
 rescue LoadError
   require "puma/events"


### PR DESCRIPTION
# Description:

Load puma/detect.rb to allow puma/log_writer.rb to work.

That latter file uses a constant that resides in puma/detect.rb.

Fixes #361 - thank you, @ktreis!


I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
