### PR TITLE
Fix branch name reference in Rake doc comment [ci skip]

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ end
 task spec: :rubocop
 task default: :spec
 
-desc "Update ChangeLog based on commits in master"
+desc "Update ChangeLog based on commits in main"
 task :changelog do
   Changelog.new.run
 end


### PR DESCRIPTION
# Description:

The branch worked on in the changelog code is `main`.

This fixes that.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
