### PR TITLE
authorize: support naming and listing authorizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Changes
+
+  - Support naming and listing authorizations ([#365](https://github.com/rubygems/gemstash/pull/365), [@kyrofa][])
+
 ## 2.3.2 (2023-09-14)
 
 https://github.com/rubygems/gemstash/compare/v2.3.1...v2.3.2

--- a/gemstash.gemspec
+++ b/gemstash.gemspec
@@ -41,6 +41,7 @@ you push your own private gems as well."
   spec.add_runtime_dependency "sequel", "~> 5.0"
   spec.add_runtime_dependency "server_health_check-rack", "~> 0.1"
   spec.add_runtime_dependency "sinatra", ">= 1.4", "< 4.0"
+  spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "thor", "~> 1.0"
 
   # Use Redis instead of memcached

--- a/lib/gemstash/authorization.rb
+++ b/lib/gemstash/authorization.rb
@@ -13,7 +13,9 @@ module Gemstash
     extend Gemstash::Logging
     VALID_PERMISSIONS = %w[push yank fetch].freeze
 
-    def self.authorize(auth_key, permissions)
+    attr_reader :name
+
+    def self.authorize(auth_key, permissions, name = nil)
       raise "Authorization key is required!" if auth_key.to_s.strip.empty?
       raise "Permissions are required!" if permissions.to_s.empty?
 
@@ -25,7 +27,7 @@ module Gemstash
         permissions = permissions.join(",")
       end
 
-      Gemstash::DB::Authorization.insert_or_update(auth_key, permissions)
+      Gemstash::DB::Authorization.insert_or_update(auth_key, permissions, name)
       gemstash_env.cache.invalidate_authorization(auth_key)
       log.info "Authorization '#{auth_key}' updated with access to '#{permissions}'"
     end
@@ -62,6 +64,7 @@ module Gemstash
 
     def initialize(record)
       @auth_key = record.auth_key
+      @name = record.name
       @all = record.permissions == "all"
       @permissions = Set.new(record.permissions.split(","))
     end

--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -51,10 +51,14 @@ module Gemstash
     desc "authorize [PERMISSIONS...]", "Add authorizations to push/yank private gems"
     method_option :remove, :type => :boolean, :default => false, :desc =>
       "Remove an authorization key"
+    method_option :list, :type => :boolean, :default => false, :desc =>
+      "List existing authorization keys"
     method_option :config_file, :type => :string, :desc =>
       "Config file to save to"
     method_option :key, :type => :string, :desc =>
       "Authorization key to create/update/delete (optional unless deleting)"
+    method_option :name, :type => :string, :desc =>
+      "Name of the key (optional)"
     def authorize(*args)
       Gemstash::CLI::Authorize.new(self, *args).run
     end

--- a/lib/gemstash/db/authorization.rb
+++ b/lib/gemstash/db/authorization.rb
@@ -6,14 +6,14 @@ module Gemstash
   module DB
     # Sequel model for authorizations table.
     class Authorization < Sequel::Model
-      def self.insert_or_update(auth_key, permissions)
+      def self.insert_or_update(auth_key, permissions, name = nil)
         db.transaction do
           record = self[auth_key: auth_key]
 
           if record
-            record.update(permissions: permissions)
+            record.update(permissions: permissions, name: name)
           else
-            create(auth_key: auth_key, permissions: permissions)
+            create(auth_key: auth_key, permissions: permissions, name: name)
           end
         end
       end

--- a/lib/gemstash/migrations/05_authorization_names.rb
+++ b/lib/gemstash/migrations/05_authorization_names.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table :authorizations do
+      add_column :name, String, :size => 191
+      add_index [:name], :unique => true
+    end
+  end
+end

--- a/man/gemstash-authorize.1.md
+++ b/man/gemstash-authorize.1.md
@@ -10,7 +10,7 @@ gemstash-authorize - Adds or removes authorization to interact with privately st
 
 # Synopsis
 
-`gemstash authorize [permissions] [--remove] [--key SECURE_KEY] [--config-file FILE]`
+`gemstash authorize [permissions] [--remove] [--list] [--key SECURE_KEY] [--name NAME] [--config-file FILE]`
 
 # Description
 
@@ -25,8 +25,10 @@ of Gemstash).
 ```
 gemstash authorize
 gemstash authorize push yank
+gemstash authorize push --name my-auth
 gemstash authorize yank --key <secure-key>
 gemstash authorize --remove --key <secure-key>
+gemstash authorize --list
 ```
 
 # Options
@@ -43,8 +45,14 @@ gemstash authorize --remove --key <secure-key>
     for the specified API key. If missing, a new API key will always be generated.
     Note that a key can only have a maximum length of 255 chars.
 
+* `--name`:
+    Name of the authorization. Purely for ease of identification, not required.
+
 * `--remove`:
     Remove an authorization rather than add or update one. When removing, permission
     values are not allowed. The `--key <secure-key>` option is required.
+
+* `--list`:
+    List current authorizations. Provide `--name` or `--key` to show only one result.
 
 [ERB_CONFIG]: ./gemstash-customize.7.md#erb-parsed-config

--- a/spec/gemstash/cli/authorize_spec.rb
+++ b/spec/gemstash/cli/authorize_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Gemstash::CLI::Authorize do
       expect { Gemstash::CLI::Authorize.new(cli).run }.to raise_error(Gemstash::CLI::Error)
     end
 
-    it "handles missing authorization" do
+    it "raises error when authorization is missing" do
       Gemstash::Authorization.authorize("auth-key-all", "all", "auth all")
       Gemstash::Authorization.authorize("auth-key-push", %w[push], "auth push")
       cli_options[:name] = "missing name"


### PR DESCRIPTION
Over time, gemstash authorizations turn into a pile of opaque tokens and associated permissions. Keeping track of which token belongs to which developer or automated system is required to enable proper revocation or rotation. Today, that requires the use of an external system, which has the added problem of duplicating the key itself.

This PR resolves #364, adding support for keeping this association within Gemstash itself by allowing for authorizations to be named. It also adds support for listing authorizations, so it's easy to determine which key needs to be revoked, rotated, or otherwise updated. See the manpage updates for details on use.