### PR TITLE
Fix a Markdown link in CHANGELOG.md [ci skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-  - Require a now-needed file for Puma 6. Thanks, [@ktreis][]! ([#362](https://github.com/rubygems/gemstash/pull/362), [@olleolleolle](https://github.com/olleolleolle))
+  - Require a now-needed file for Puma 6. Thanks, [@ktreis](https://github.com/ktreis)! ([#362](https://github.com/rubygems/gemstash/pull/362), [@olleolleolle](https://github.com/olleolleolle))
 
 ## 2.3.1 (2023-09-05)
 


### PR DESCRIPTION


# Description:

This makes a link work correctly, now that we do not use "reference-style Markdown links" (see the rake/changelog.citrus grammar file and the changelog rake task).



I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
