### PR TITLE
Move documentation changes to man/ which is the source

### DIFF
--- a/docs/gemstash-multiple-sources.7.md
+++ b/docs/gemstash-multiple-sources.7.md
@@ -61,17 +61,18 @@ you want. The `/upstream` prefix tells Gemstash to use a gem source
 other than the default source. You can now bundle with the additional
 source.
 
-Notice that the third source doesn't need to be escaped.
-This is because the `https://` is used by default when no scheme is set,
-and the source URL does not contain any chars that need to be escaped.
+Notice that the third source doesn’t need to be escaped. This is because
+the `https://` is used by default when no scheme is set, and the source
+URL does not contain any characters that need to be escaped.
 
 ## Authentication with Multiple Sources
 
-You can use basic authentication or API keys on sources directly in Gemfile
-or using ENV variables on the Gemstash instance.
+You can use basic authentication or API keys on sources directly in
+Gemfile or using ENV variables on the Gemstash instance.
 
 Example `Gemfile`:
-```ruby
+
+``` ruby
 # ./Gemfile
 require "cgi"
 source "http://localhost:9292"
@@ -85,10 +86,10 @@ source "http://localhost:9292/upstream/#{CGI.escape("api_key@my-other.gem-source
 end
 ```
 
-If you set `GEMSTASH_<HOST>` ENV variable with your authentication information,
-you can omit it from the `Gemfile`:
+If you set `GEMSTASH_<HOST>` ENV variable with your authentication
+information, you can omit it from the `Gemfile`:
 
-```ruby
+``` ruby
 # ./Gemfile
 source "http://localhost:9292"
 
@@ -99,15 +100,16 @@ end
 
 And run the Gemstash with the credentials set in an ENV variable:
 
-```bash
+``` bash
 GEMSTASH_MY__GEM___SOURCE__LOCAL=user:password gemstash start --no-daemonize --config-file config.yml.erb
 ```
 
 The name of the ENV variable is the uppercase version of the host name,
-with all `.` characters replaced with `__`, all `-` with `___` and a `GEMSTASH_` prefix 
-(it uses the same syntax as [Bundler](https://bundler.io/v2.4/man/bundle-config.1.html#CREDENTIALS-FOR-GEM-SOURCES)).
+with all `.` characters replaced with `__`, all `-` with `___` and a
+`GEMSTASH_` prefix (it uses the same syntax as
+[Bundler](https://bundler.io/v2.4/man/bundle-config.1.html#CREDENTIALS-FOR-GEM-SOURCES)).
 
-Example: `my.gem-source.local` => `GEMSTASH_MY__GEM___SOURCE__LOCAL`
+Example: `my.gem-source.local` =\> `GEMSTASH_MY__GEM___SOURCE__LOCAL`
 
 ## Redirecting
 

--- a/man/gemstash-multiple-sources.7.md
+++ b/man/gemstash-multiple-sources.7.md
@@ -40,6 +40,7 @@ https://rubygems.org along with additional sources. If you need to bundle with
 multiple gem sources, Gemstash doesn't need to be specially configured. Your
 Gemstash server will honor any gem source specified via a specialized URL.
 Consider the following `Gemfile`:
+
 ```ruby
 # ./Gemfile
 require "cgi"
@@ -49,12 +50,64 @@ gem "rubywarrior"
 source "http://localhost:9292/upstream/#{CGI.escape("https://my.gem-source.local")}" do
   gem "my-gem"
 end
+
+source "http://localhost:9292/upstream/my-other.gem-source.local" do
+  gem "my-other-gem"
+end
 ```
 
 Notice the `CGI.escape` call in the second source. This is important, as it
 properly URL escapes the source URL so Gemstash knows what gem source you want.
 The `/upstream` prefix tells Gemstash to use a gem source other than the default
 source. You can now bundle with the additional source.
+
+Notice that the third source doesn't need to be escaped.
+This is because the `https://` is used by default when no scheme is set,
+and the source URL does not contain any characters that need to be escaped.
+
+## Authentication with Multiple Sources
+
+You can use basic authentication or API keys on sources directly in Gemfile
+or using ENV variables on the Gemstash instance.
+
+Example `Gemfile`:
+```ruby
+# ./Gemfile
+require "cgi"
+source "http://localhost:9292"
+
+source "http://localhost:9292/upstream/#{CGI.escape("user:password@my.gem-source.local")}" do
+  gem "my-gem"
+end
+
+source "http://localhost:9292/upstream/#{CGI.escape("api_key@my-other.gem-source.local")}" do
+  gem "my-other-gem"
+end
+```
+
+If you set `GEMSTASH_<HOST>` ENV variable with your authentication information,
+you can omit it from the `Gemfile`:
+
+```ruby
+# ./Gemfile
+source "http://localhost:9292"
+
+source "http://localhost:9292/upstream/my.gem-source.local" do
+  gem "my-gem"
+end
+```
+
+And run the Gemstash with the credentials set in an ENV variable:
+
+```bash
+GEMSTASH_MY__GEM___SOURCE__LOCAL=user:password gemstash start --no-daemonize --config-file config.yml.erb
+```
+
+The name of the ENV variable is the uppercase version of the host name,
+with all `.` characters replaced with `__`, all `-` with `___` and a `GEMSTASH_` prefix 
+(it uses the same syntax as [Bundler](https://bundler.io/v2.4/man/bundle-config.1.html#CREDENTIALS-FOR-GEM-SOURCES)).
+
+Example: `my.gem-source.local` => `GEMSTASH_MY__GEM___SOURCE__LOCAL`
 
 ## Redirecting
 


### PR DESCRIPTION
# Description:

#339 was just merged, and the documentation was added, but to the _generated_ files.

This PR makes the changes in the _source files_, which can be found in `man/`. A separate commit has the result of running the rake task `doc`.

After this, running `rake doc` makes no change to the working copy.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
