### PR TITLE
configuration: support GEMSTASH_CONFIG environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Changes
+
+  - Support `GEMSTASH_CONFIG` environment variable ([#369](https://github.com/rubygems/gemstash/pull/369), [@kyrofa](https://github.com/kyrofa))
+
 ## 2.5.0 (2023-09-28)
 
 - Add support for upstream auth with ENV variables ([#339](https://github.com/rubygems/gemstash/pull/339), [@CiTroNaK](https://github.com/CiTroNaK))

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -75,6 +75,11 @@ module Gemstash
   private
 
     def default_file
+      # Support the config file being specified via environment variable
+      gemstash_config = ENV["GEMSTASH_CONFIG"]
+      return gemstash_config if gemstash_config
+
+      # If no environment variable is used, fall back to the normal defaults
       File.exist?("#{DEFAULT_FILE}.erb") ? "#{DEFAULT_FILE}.erb" : DEFAULT_FILE
     end
 

--- a/spec/gemstash/configuration_spec.rb
+++ b/spec/gemstash/configuration_spec.rb
@@ -46,4 +46,24 @@ RSpec.describe Gemstash::Configuration do
       expect(env.config[:db_adapter]).to eq("sqlite3")
     end
   end
+
+  context "config from GEMSTASH_CONFIG environment variable" do
+    let(:env) { Gemstash::Env.new }
+
+    before do
+      @original_gemstash_config = ENV["GEMSTASH_CONFIG"]
+      ENV["GEMSTASH_CONFIG"] = "#{config_dir}/config.yml"
+    end
+
+    after do
+      ENV.delete("GEMSTASH_CONFIG")
+      ENV["GEMSTASH_CONFIG"] = @original_gemstash_config unless @original_gemstash_config.nil?
+    end
+
+    it "loads successfully and is merged with defaults" do
+      expect(env.config[:db_adapter]).to eq("postgres")
+      expect(env.config[:db_url]).to eq("postgres://gemstash")
+      expect(env.config[:rubygems_url]).to eq("https://rubygems.org")
+    end
+  end
 end


### PR DESCRIPTION
Some gemstash configurations don't have a `/home/gemstash` directory (e.g. minimal Docker installations), and prefer to store their Gemstash configuration elsewhere (e.g. in a system-wide location such as `/etc/gemstash/config.yml`). Today, such use-cases require every Gemstash command to be accompanied by the `--config-file` CLI option, and forgetting to do so causes Gemstash to use its default settings.

This PR resolves #369, smoothing the wrinkles for this use-case, by supporting defining the path to one's configuration in the `GEMSTASH_CONFIG` environment variable.