### PR TITLE
Fix uninitialized constant error when using Redis cache

### DIFF
--- a/lib/gemstash.rb
+++ b/lib/gemstash.rb
@@ -20,6 +20,7 @@ module Gemstash
   autoload :LruReduxClient,      "gemstash/cache"
   autoload :NotAuthorizedError,  "gemstash/authorization"
   autoload :RackEnvRewriter,     "gemstash/rack_env_rewriter"
+  autoload :RedisClient,         "gemstash/cache"
   autoload :Resource,            "gemstash/storage"
   autoload :SpecsBuilder,        "gemstash/specs_builder"
   autoload :Storage,             "gemstash/storage"

--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -90,8 +90,8 @@ module Gemstash
 
       def ask_redis_details
         say_current_config(:redis_servers, "Current Redis servers")
-        servers = @cli.ask "What is the comma-separated list of Redis servers? [localhost:6379]"
-        servers = "localhost:6379" if servers.empty?
+        servers = @cli.ask "What is the comma-separated list of Redis servers? [redis://localhost:6379]"
+        servers = "redis://localhost:6379" if servers.empty?
         @config[:redis_servers] = servers
       end
 


### PR DESCRIPTION
# Description:

This change adds `RedisClient` to the autoload list.  Without this change, an uninitialized constant error is raised when running setup and entering the `redis` cache (example output below).  I also updated the default Redis connection string since the following error is thrown without having a scheme provided:
```
Error checking cache: Invalid URL: "localhost:6379"
```

I started to add tests, but couldn't reproduce it there without possibly affecting all tests.  Since [this line](https://github.com/chris72205/gemstash/blob/9f0340e4f1b2fa34528babb6756630677cf4187b/spec/spec_helper.rb#L58) loads `lib/gemstash/cache.rb`, `Gemstash::RedisClient` becomes initialized.

```
bin/gemstash setup --debug --redo
Where should files go? [~/.gemstash]
Cache with what? [MEMORY, memcached, redis] redis
What is the comma-separated list of Redis servers? [localhost:6379]
What database adapter? [SQLITE3, postgres, mysql, mysql2]
Use Protected Fetch for Private Gems? [y/N] y
How many seconds to wait when fetching a gem? [20]
Checking that the cache is available
Error checking cache: uninitialized constant Gemstash::RedisClient
  [...]/gemstash/lib/gemstash/env.rb:174:in `cache_client'
  [...]/gemstash/lib/gemstash/cli/setup.rb:134:in `block in check_cache'
  [...]/gemstash/lib/gemstash/cli/setup.rb:187:in `with_new_config'
  [...]/gemstash/lib/gemstash/cli/setup.rb:194:in `try'
  [...]/gemstash/lib/gemstash/cli/setup.rb:134:in `check_cache'
  [...]/gemstash/lib/gemstash/cli/setup.rb:29:in `run'
  [...]/gemstash/lib/gemstash/cli.rb:74:in `setup'
  [...]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
  [...]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
  [...]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
  [...]/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/base.rb:485:in `start'
  [...]/gemstash/lib/gemstash/cli.rb:34:in `start'
  bin/gemstash:4:in `<main>'
The cache is not available
```
______________

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
