### PR TITLE
Remove the daemonize feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
   - Fix uninitialized constant error when using Redis cache ([#375](https://github.com/rubygems/gemstash/pull/375), [@chris72205](https://github.com/chris72205))
+  - Remove --daemonize option, no longer supported by Puma.
 
 ## 2.6.0 (2023-09-30)
 

--- a/docs/gemstash-configuration.5.md
+++ b/docs/gemstash-configuration.5.md
@@ -245,6 +245,3 @@ placed in the [base path](docs/gemstash-configuration.5.md#base-path).
 ## Valid values
 
 Any valid file name, or `:stdout` to log to `$stdout`
-
-*Note: Using `:stdout` for the `:log_file` requires [running with
-`--no-daemonize`](docs/gemstash-start.1.md#options).*

--- a/docs/gemstash-debugging.7.md
+++ b/docs/gemstash-debugging.7.md
@@ -8,12 +8,10 @@ might want to start by looking at the server log. You can find the log
 at `server.log` within your base directory. By default, this will be at
 `~/.gemstash/server.log`.
 
-You might find it easier to view the log directly in your terminal. If
-you run Gemstash [in non-daemonized
-form](docs/gemstash-start.1.md#options), the log will be output directly to
-standard out:
+You might find it easier to view the log directly in your terminal.
+Gemstash outputs its log directly to standard out:
 
-    $ gemstash start --no-daemonize
+    $ gemstash start
 
 You can also [check the status](docs/gemstash-status.1.md) of the server:
 

--- a/docs/gemstash-multiple-sources.7.md
+++ b/docs/gemstash-multiple-sources.7.md
@@ -101,7 +101,7 @@ end
 And run the Gemstash with the credentials set in an ENV variable:
 
 ``` bash
-GEMSTASH_MY__GEM___SOURCE__LOCAL=user:password gemstash start --no-daemonize --config-file config.yml.erb
+GEMSTASH_MY__GEM___SOURCE__LOCAL=user:password gemstash start --config-file config.yml.erb
 ```
 
 The name of the ENV variable is the uppercase version of the host name,

--- a/docs/gemstash-start.1.md
+++ b/docs/gemstash-start.1.md
@@ -7,7 +7,7 @@ gemstash-start - Starts the Gemstash server
 
 # Synopsis
 
-`gemstash start [--no-daemonize] [--config-file FILE]`
+`gemstash start [--config-file FILE]`
 
 # Description
 
@@ -19,7 +19,3 @@ Starts the Gemstash server.
   using the default config file at `~/.gemstash/config.yml` or
   [`~/.gemstash/config.yml.erb`](docs/gemstash-customize.7.md#erb-parsed-config),
   then you must specify the config file via this option.
-
-- `--no-daemonize`: The Gemstash server daemonizes itself by default.
-  Provide this option to instead run the server until `Ctrl-C` is typed.
-  When not daemonized, the log will be output to standard out.

--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -75,8 +75,6 @@ module Gemstash
     end
 
     desc "start", "Starts your gemstash server"
-    method_option :daemonize, :type => :boolean, :default => true, :desc =>
-      "Daemonize the server"
     method_option :config_file, :type => :string, :desc =>
       "Config file to load when starting"
     def start

--- a/lib/gemstash/cli/start.rb
+++ b/lib/gemstash/cli/start.rb
@@ -10,46 +10,22 @@ module Gemstash
     class Start < Gemstash::CLI::Base
       def run
         prepare
-        setup_logging
-        store_daemonized
         @cli.say("Starting gemstash!", :green)
         Puma::CLI.new(args, Gemstash::Logging::StreamLogger.puma_events).run
       end
 
     private
 
-      def setup_logging
-        return unless daemonize?
-
-        Gemstash::Logging.setup_logger(gemstash_env.log_file)
-      end
-
-      def store_daemonized
-        Gemstash::Env.daemonized = daemonize?
-      end
-
-      def daemonize?
-        @cli.options[:daemonize]
-      end
-
       def puma_config
         File.expand_path("../puma.rb", __dir__)
       end
 
       def args
-        config_args + pidfile_args + daemonize_args
+        config_args + pidfile_args
       end
 
       def config_args
         ["--config", puma_config]
-      end
-
-      def daemonize_args
-        if daemonize?
-          ["--daemon"]
-        else
-          []
-        end
       end
     end
   end

--- a/lib/gemstash/config.ru
+++ b/lib/gemstash/config.ru
@@ -6,8 +6,6 @@ require "puma/commonlogger"
 use Rack::Deflater
 use Gemstash::Logging::RackMiddleware
 
-use Puma::CommonLogger, Gemstash::Logging::StreamLogger.for_stdout if Gemstash::Env.daemonized?
-
 use Gemstash::Env::RackMiddleware, Gemstash::Env.current
 use Gemstash::GemSource::RackMiddleware
 use Gemstash::Health::RackMiddleware

--- a/lib/gemstash/env.rb
+++ b/lib/gemstash/env.rb
@@ -59,17 +59,6 @@ module Gemstash
       Thread.current[:gemstash_env] = value
     end
 
-    def self.daemonized?
-      raise "Daemonized hasn't been set yet!" if @daemonized.nil?
-
-      @daemonized
-    end
-
-    def self.daemonized=(value)
-      value = false if value.nil?
-      @daemonized = value
-    end
-
     def config
       @config ||= Gemstash::Configuration.new
     end

--- a/man/gemstash-configuration.5.md
+++ b/man/gemstash-configuration.5.md
@@ -239,11 +239,8 @@ the [base path][BASE_PATH].
 
 Any valid file name, or `:stdout` to log to `$stdout`
 
-*Note: Using `:stdout` for the `:log_file` requires [running with `--no-daemonize`][NO_DAEMONIZE].*
-
 [SETUP]: ./gemstash-setup.1.md
 [SEQUEL]: http://sequel.jeremyevans.net/
 [SEQUEL_CONNECT]: http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-General+connection+options
 [PUMA_BINDING]: https://github.com/puma/puma#binding-tcp--sockets
 [BASE_PATH]: ./gemstash-configuration.5.md#base-path
-[NO_DAEMONIZE]: ./gemstash-start.1.md#options

--- a/man/gemstash-debugging.7.md
+++ b/man/gemstash-debugging.7.md
@@ -11,11 +11,11 @@ to start by looking at the server log. You can find the log at `server.log`
 within your base directory. By default, this will be at
 `~/.gemstash/server.log`.
 
-You might find it easier to view the log directly in your terminal. If you run
-Gemstash [in non-daemonized form][START_OPTIONS], the log will be
-output directly to standard out:
+You might find it easier to view the log directly in your terminal. Gemstash
+outputs its log directly to standard out:
+
 ```
-$ gemstash start --no-daemonize
+$ gemstash start
 ```
 
 You can also [check the status][STATUS] of the server:

--- a/man/gemstash-multiple-sources.7.md
+++ b/man/gemstash-multiple-sources.7.md
@@ -100,11 +100,11 @@ end
 And run the Gemstash with the credentials set in an ENV variable:
 
 ```bash
-GEMSTASH_MY__GEM___SOURCE__LOCAL=user:password gemstash start --no-daemonize --config-file config.yml.erb
+GEMSTASH_MY__GEM___SOURCE__LOCAL=user:password gemstash start --config-file config.yml.erb
 ```
 
 The name of the ENV variable is the uppercase version of the host name,
-with all `.` characters replaced with `__`, all `-` with `___` and a `GEMSTASH_` prefix 
+with all `.` characters replaced with `__`, all `-` with `___` and a `GEMSTASH_` prefix
 (it uses the same syntax as [Bundler](https://bundler.io/v2.4/man/bundle-config.1.html#CREDENTIALS-FOR-GEM-SOURCES)).
 
 Example: `my.gem-source.local` => `GEMSTASH_MY__GEM___SOURCE__LOCAL`

--- a/man/gemstash-start.1.md
+++ b/man/gemstash-start.1.md
@@ -10,7 +10,7 @@ gemstash-start - Starts the Gemstash server
 
 # Synopsis
 
-`gemstash start [--no-daemonize] [--config-file FILE]`
+`gemstash start [--config-file FILE]`
 
 # Description
 
@@ -22,10 +22,5 @@ Starts the Gemstash server.
     Specify the config file to use. If you aren't using the default config file
     at `~/.gemstash/config.yml` or [`~/.gemstash/config.yml.erb`][ERB_CONFIG],
     then you must specify the config file via this option.
-
-* `--no-daemonize`:
-    The Gemstash server daemonizes itself by default. Provide this option to instead
-    run the server until `Ctrl-C` is typed. When not daemonized, the log will be
-    output to standard out.
 
 [ERB_CONFIG]: ./gemstash-customize.7.md#erb-parsed-config


### PR DESCRIPTION
# Description:

This is a Pull Request which removes the `--daemonize` option, its documentation, and all related mentions.

Puma no longer supports it. There are new, other ways to do that.

This closes #359 with a more-final change.

Perhaps this means that there we may need new ways of enabling a Puma::CommonLogger, of enabling non-stdout output (that is "setup_logger") in the Gemstash server.

Now, gemstash operates "in front, in the terminal it is started".

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
