### PR TITLE
Fix a link in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-  - Fix uninitialized constant error when using Redis cache ([#375](https://github.com/rubygems/gemstash/pull/375), [@ chris72205](https://github.com/ chris72205))
+  - Fix uninitialized constant error when using Redis cache ([#375](https://github.com/rubygems/gemstash/pull/375), [@chris72205](https://github.com/chris72205))
 
 ## 2.6.0 (2023-09-30)
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 Gemstash is both a cache for remote servers such as
 https://rubygems.org, and a private gem source.
 
-If you are using [bundler](http://bundler.io/) across many machines that
-have access to a server within your control, you might want to use
+If you are using [bundler](https://bundler.io/) across many machines
+that have access to a server within your control, you might want to use
 Gemstash.
 
 If you produce gems that you don’t want everyone in the world to have
@@ -129,9 +129,9 @@ memory. Gem files are always cached permanently, so bundling with a
 `Gemfile.lock` with all gems cached will never call out to
 https://rubygems.org.
 
-The server you ran is provided via [Puma](http://puma.io/) and
-[Rack](http://rack.github.io/), however they are not customizable at
-this point.
+The server you ran is provided via [Puma](https://puma.io/) and
+[Rack](https://github.com/rack/rack), however they are not customizable
+at this point.
 
 ## Deep Dive
 
@@ -158,7 +158,7 @@ An anatomy of various configuration and commands:
 - [Version](docs/gemstash-version.1.md)
 
 To see what has changed in recent versions of Gemstash, see the
-[CHANGELOG](https://github.com/rubygems/gemstash/blob/master/CHANGELOG.md).
+[CHANGELOG](https://github.com/rubygems/gemstash/blob/main/CHANGELOG.md).
 
 ## Development
 
@@ -173,7 +173,7 @@ Bug reports and pull requests are welcome on GitHub at
 https://github.com/rubygems/gemstash. This project is intended to be a
 safe, welcoming space for collaboration, and contributors are expected
 to adhere to the [Contributor
-Covenant](https://github.com/rubygems/gemstash/blob/master/CODE_OF_CONDUCT.md)
+Covenant](https://github.com/rubygems/gemstash/blob/main/CODE_OF_CONDUCT.md)
 code of conduct.
 
 ## License

--- a/man/gemstash-readme.7.md
+++ b/man/gemstash-readme.7.md
@@ -193,15 +193,15 @@ the [Contributor Covenant][CODE_OF_CONDUCT] code of conduct.
 The gem is available as open source under the terms of the
 [MIT License][LICENSE].
 
-[BUNDLER]: http://bundler.io/
+[BUNDLER]: https://bundler.io/
 [RUBY_CENTRAL]: https://rubycentral.org/
 [RUBY_CENTRAL_SIGNUP]: https://rubycentral.org/#/portal/signup
 [CUSTOMIZE_FILES]: ./gemstash-customize.7.md#files
 [SQLITE]: https://www.sqlite.org/
 [CUSTOMIZE_DATABASE]: ./gemstash-customize.7.md#database
 [CUSTOMIZE_CACHE]: ./gemstash-customize.7.md#cache
-[PUMA]: http://puma.io/
-[RACK]: http://rack.github.io/
+[PUMA]: https://puma.io/
+[RACK]: https://github.com/rack/rack
 [PRIVATE_GEMS]: ./gemstash-private-gems.7.md
 [MULTIPLE_SOURCES]: ./gemstash-multiple-sources.7.md
 [MIRROR]: ./gemstash-mirror.7.md
@@ -215,6 +215,6 @@ The gem is available as open source under the terms of the
 [STATUS]: ./gemstash-status.1.md
 [SETUP]: ./gemstash-setup.1.md
 [VERSION]: ./gemstash-version.1.md
-[CHANGELOG]: https://github.com/rubygems/gemstash/blob/master/CHANGELOG.md
-[CODE_OF_CONDUCT]: https://github.com/rubygems/gemstash/blob/master/CODE_OF_CONDUCT.md
+[CHANGELOG]: https://github.com/rubygems/gemstash/blob/main/CHANGELOG.md
+[CODE_OF_CONDUCT]: https://github.com/rubygems/gemstash/blob/main/CODE_OF_CONDUCT.md
 [LICENSE]: http://opensource.org/licenses/MIT


### PR DESCRIPTION
# Description:

I saw that some links were outdated. This updates them, and regenerates the README.

Also, fix a Markdown typo in CHANGELOG.


I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
