### PR TITLE
Reinstate nonfunctional --no-daemonize, --daemonize options that warn

### DIFF
--- a/lib/gemstash/cli.rb
+++ b/lib/gemstash/cli.rb
@@ -75,6 +75,8 @@ module Gemstash
     end
 
     desc "start", "Starts your gemstash server"
+    method_option :daemonize, :type => :boolean, :default => nil, :desc =>
+       "No effect - functionality removed, option kept for compatibility"
     method_option :config_file, :type => :string, :desc =>
       "Config file to load when starting"
     def start

--- a/lib/gemstash/cli/start.rb
+++ b/lib/gemstash/cli/start.rb
@@ -11,6 +11,10 @@ module Gemstash
       def run
         prepare
         @cli.say("Starting gemstash!", :green)
+        case @cli.options[:daemonize]
+        when false then warn "The --no-daemonize option was removed and has no effect."
+        when true then warn "The --daemonize option was removed and has no effect."
+        end
         Puma::CLI.new(args, Gemstash::Logging::StreamLogger.puma_events).run
       end
 


### PR DESCRIPTION
# Description:

Reinstate a `--daemonize` and `--no-daemonize` which only warn.

Follow-up to #378 and fixes the problem in #380.

# Tasks:

-  Describe the problem / feature
-  Write tests

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
