### PR TITLE
add a configurable connection open timeout

### DIFF
--- a/docs/gemstash-configuration.5.md
+++ b/docs/gemstash-configuration.5.md
@@ -24,6 +24,7 @@ gemstash-configuration
 :bind: tcp://0.0.0.0:4242
 :protected_fetch: true
 :fetch_timeout: 10
+:open_timeout: 2
 :log_file: gemstash.log
 ```
 
@@ -219,13 +220,33 @@ Boolean values `true` or `false`
 
 `:fetch_timeout`
 
-The timeout setting for fetching gems. Fetching gems over a slow
-connection may cause timeout errors. If you experience timeout errors,
-you may want to increase this value. The default is `20` seconds.
+This is the number of seconds to allow for fetching a gem from upstream.
+It covers establishing the connection and receiving the response. Fetching
+gems over a slow connection may cause timeout errors. If you experience
+timeout errors, you may want to increase this value. The default is `20`
+seconds.
 
 ## Default value
 
 `20`
+
+## Valid values
+
+Integer value with a minimum of `1`
+
+# Open Timeout
+
+`:open_timeout`
+
+The timeout setting for opening the connection to an upstream gem
+server. On high-latency networks, even establishing the connection
+to an upstream gem server can take a while. If you experience
+connection failures instead of timeout errors, you may want to
+increase this value. The default is `2` seconds.
+
+## Default value
+
+`2`
 
 ## Valid values
 

--- a/docs/gemstash-customize.7.md
+++ b/docs/gemstash-customize.7.md
@@ -179,6 +179,16 @@ configuration key to change it.
 :fetch_timeout: 20
 ```
 
+## Open Timeout
+
+The default connection open timeout is 2 seconds. Use the
+`:open_timeout` configuration key to change it.
+
+``` yaml
+---
+:open_timeout: 2
+```
+
 ## Config File Location
 
 By default, configuration for Gemstash will be at

--- a/lib/gemstash/cli/setup.rb
+++ b/lib/gemstash/cli/setup.rb
@@ -25,7 +25,8 @@ module Gemstash
         ask_cache
         ask_database
         ask_protected_fetch
-        ask_timeout
+        ask_fetch_timeout
+        ask_open_timeout
         check_cache
         check_storage
         check_database
@@ -123,11 +124,18 @@ module Gemstash
         @config[:protected_fetch] = value
       end
 
-      def ask_timeout
+      def ask_fetch_timeout
         say_current_config(:fetch_timeout, "Fetch timeout")
-        timeout = @cli.ask "How many seconds to wait when fetching a gem? [20]"
+        timeout = @cli.ask "How many seconds to wait for fetching a gem to complete? [20]"
         timeout = Gemstash::Configuration::DEFAULTS[:fetch_timeout] if timeout.to_i < 1
         @config[:fetch_timeout] = timeout.to_i
+      end
+
+      def ask_open_timeout
+        say_current_config(:open_timeout, "Open timeout")
+        timeout = @cli.ask "How many seconds to wait for connection to upstream gem server to be established? [2]"
+        timeout = Gemstash::Configuration::DEFAULTS[:open_timeout] if timeout.to_i < 1
+        @config[:open_timeout] = timeout.to_i
       end
 
       def check_cache

--- a/lib/gemstash/configuration.rb
+++ b/lib/gemstash/configuration.rb
@@ -15,6 +15,7 @@ module Gemstash
       ignore_gemfile_source: false,
       protected_fetch: false,
       fetch_timeout: 20,
+      open_timeout: 2,
       # Actual default for db_connection_options is dynamic based on the adapter
       db_connection_options: {},
       puma_threads: 16,

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -55,7 +55,7 @@ module Gemstash
       response = with_retries do
         @client.get(path) do |req|
           req.headers["User-Agent"] = @user_agent
-          req.options.open_timeout = 2
+          req.options.open_timeout = gemstash_env.config[:fetch_timeout]
         end
       end
 

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -25,6 +25,7 @@ module Gemstash
   # :nodoc:
   class HTTPClient
     extend Gemstash::Env::Helper
+    include Gemstash::Env::Helper
     include Gemstash::Logging
 
     DEFAULT_USER_AGENT = "Gemstash/#{Gemstash::VERSION}"
@@ -55,7 +56,7 @@ module Gemstash
       response = with_retries do
         @client.get(path) do |req|
           req.headers["User-Agent"] = @user_agent
-          req.options.open_timeout = 10
+          req.options.open_timeout = gemstash_env.config[:open_timeout]
         end
       end
 

--- a/lib/gemstash/http_client.rb
+++ b/lib/gemstash/http_client.rb
@@ -55,7 +55,7 @@ module Gemstash
       response = with_retries do
         @client.get(path) do |req|
           req.headers["User-Agent"] = @user_agent
-          req.options.open_timeout = gemstash_env.config[:fetch_timeout]
+          req.options.open_timeout = 10
         end
       end
 

--- a/man/gemstash-configuration.5.md
+++ b/man/gemstash-configuration.5.md
@@ -27,6 +27,7 @@ gemstash-configuration
 :bind: tcp://0.0.0.0:4242
 :protected_fetch: true
 :fetch_timeout: 10
+:open_timeout: 2
 :log_file: gemstash.log
 ```
 
@@ -212,13 +213,33 @@ Boolean values `true` or `false`
 
 `:fetch_timeout`
 
-The timeout setting for fetching gems. Fetching gems over a slow connection may
-cause timeout errors. If you experience timeout errors, you may want to increase
-this value. The default is `20` seconds.
+This is the number of seconds to allow for fetching a gem from upstream.
+It covers establishing the connection and receiving the response. Fetching
+gems over a slow connection may cause timeout errors. If you experience
+timeout errors, you may want to increase this value. The default is `20`
+seconds.
 
 ## Default value
 
 `20`
+
+## Valid values
+
+Integer value with a minimum of `1`
+
+# Open Timeout
+
+`:open_timeout`
+
+The timeout setting for opening the connection to an upstream gem
+server. On high-latency networks, even establishing the connection
+to an upstream gem server can take a while. If you experience
+connection failures instead of timeout errors, you may want to
+increase this value. The default is `2` seconds.
+
+## Default value
+
+`2`
 
 ## Valid values
 

--- a/man/gemstash-customize.7.md
+++ b/man/gemstash-customize.7.md
@@ -167,6 +167,16 @@ key to change it.
 :fetch_timeout: 20
 ```
 
+## Open Timeout
+
+The default connection open timeout is 2 seconds. Use the
+`:open_timeout` configuration key to change it.
+
+``` yaml
+---
+:open_timeout: 2
+```
+
 ## Config File Location
 
 By default, configuration for Gemstash will be at `~/.gemstash/config.yml`. This


### PR DESCRIPTION
# Description:

* Resolves #386 by making the connect open timeout configurable
______________

# Tasks:

- [x] Add `:open_timeout` to config options
  - [x] Include `Gemstash::Env::Helper` in `HTTPClient` to make `gemstash_env` available as an instance method
  - [x]  Use `gemstash_env` to lookup new config option value when making requests
- [x] Update docs
  - [x] Add `:open_timeout` to docs and describe why someone would want to change it
  - [x] Rephrase `:fetch_timeout` to make clear that it is the time for the entire open-receive-read process to complete
- [ ] Write tests
  - I do not currently know a way to test the socket open timeout in the test suite. I am open to guidance because I would love to.

✅ I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md). 💞 
