### PR TITLE
Add .mailmap to repair git author names

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+#
+# This list is used by git-shortlog to fix a few botched name translations
+# in the git archive, either because the author's full name was messed up
+# and/or not always written the same way, making contributions from the
+# same person appearing not to be so.
+#
+
+Robb Kidd <robb@thekidds.org> <robb@thekidds.og>


### PR DESCRIPTION
# Description:

Robb made a contribution. His git config was a little off.

This PR adds [a .mailmap file](https://git-scm.com/docs/gitmailmap) which tells git about the issue - use the given identity (spelling with .org, not .og) when you see the misspelled one in the commits.

Robb mentioned the issue in:
https://github.com/rubygems/gemstash/pull/387#issuecomment-2145531272

---

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
