### PR TITLE
CI: remove an upgrade of RubyGems, which seemed to be about old needs

### DIFF
--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # 'bundle install' and cache
-      - run: gem update --system
       - name: increase ulimit
         run: ulimit -n 8192
       - name: Run Tests


### PR DESCRIPTION

# Description:

This PR removes a line in the CI configuration - a line which upgraded RubyGems. We no longer need it.

This was necessary at a time when we were supporting very old Ruby versions. See https://github.com/rubygems/gemstash/commit/a0050b14c45c3c84f9145f0226267cbf3becb06d



I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
