### PR TITLE
Minimize specs in SpecsBuilder

### DIFF
--- a/lib/gemstash/db/version.rb
+++ b/lib/gemstash/db/version.rb
@@ -16,11 +16,6 @@ module Gemstash
         update(indexed: true)
       end
 
-      # This converts to the format used by /private/specs.4.8.gz
-      def to_spec
-        [rubygem.name, Gem::Version.new(number), platform]
-      end
-
       def self.slug(params)
         version = params[:version]
         platform = params[:platform]

--- a/lib/gemstash/specs_builder.rb
+++ b/lib/gemstash/specs_builder.rb
@@ -70,11 +70,25 @@ module Gemstash
     end
 
     def fetch_versions
-      @versions = Gemstash::DB::Version.for_spec_collection(prerelease: @prerelease, latest: @latest).map(&:to_spec)
+      @versions = Gemstash::DB::Version.for_spec_collection(prerelease: @prerelease, latest: @latest)
     end
 
     def marshal
-      @marshal ||= Marshal.dump(@versions)
+      @marshal ||= Marshal.dump(minimize_specs(@versions))
+    end
+
+    def minimize_specs(data)
+      names     = Hash.new {|h, k| h[k] = k }
+      versions  = Hash.new {|h, k| h[k] = Gem::Version.new(k) }
+      platforms = Hash.new {|h, k| h[k] = k }
+
+      data.map do |version|
+        [
+          names[version.rubygem.name],
+          versions[version.number],
+          platforms[version.platform]
+        ]
+      end
     end
 
     def gzip


### PR DESCRIPTION
This is what rubygems.org does to de-dupe strings in the generated marshal, which can make the resulting document much smaller and more efficient for clients to load

# Description:

______________

# Tasks:

-  Describe the problem / feature
-  Write tests

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).