### PR TITLE
Fix link to quickstart guide

### DIFF
--- a/docs/gemstash-private-gems.7.md
+++ b/docs/gemstash-private-gems.7.md
@@ -5,7 +5,7 @@
 
 Stashing private gems in your Gemstash server requires a bit of
 additional setup. If you haven’t read through the [Quickstart
-Guide](../readme.md#quickstart-guide), you should do that first. By the
+Guide](../README.md#quickstart-guide), you should do that first. By the
 end of this guide, you will be able to interact with your Gemstash
 server to store and retrieve your private gems.
 


### PR DESCRIPTION
It was using lowercase `readme.md` not `README.md`.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).