### PR TITLE
Doc task: land man page into man/

### DIFF
--- a/rakelib/doc.rake
+++ b/rakelib/doc.rake
@@ -71,7 +71,7 @@ class Doc
     end
 
     def export_to_man_and_txt
-      path = export_path("lib/gemstash/man", to_extension(""))
+      path = export_path("man", to_extension(""))
       export "man", path
       system "groff -Wall -mtty-char -mandoc -Tascii #{path} | col -b > #{path}.txt"
     end


### PR DESCRIPTION
# Description:

We use Pandoc and groff to make man page files in roff and text formats.

Those files were generated into the lib/gemstash/man directory, where the CLI tools aren't looking for them.

#396 shows what that leads to: no man pages are found.

This PR changes the output directory of the export to be `man/`.

---

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
