### PR TITLE
Bypass string_agg on jruby until jdbc-sqlite3 supports it

### DIFF
--- a/lib/gemstash/db.rb
+++ b/lib/gemstash/db.rb
@@ -11,7 +11,7 @@ module Gemstash
     Sequel::Model.raise_on_save_failure = true
     Sequel::Model.plugin :timestamps, update_on_create: true
     Sequel::Model.db.extension :error_sql
-    Sequel::Model.db.extension :string_agg
+    Sequel::Model.db.extension :string_agg if RUBY_PLATFORM != "java"
     Sequel::Model.db.extension :schema_dumper
     autoload :Authorization, "gemstash/db/authorization"
     autoload :CachedRubygem, "gemstash/db/cached_rubygem"


### PR DESCRIPTION
# Description:

Aggregate dependencies the old fashioned way on jruby until jdbc-sqlite3 supports string_agg.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
