### PR TITLE
docs: add macOS dependency instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,29 @@ Then, run `rake` to run RuboCop and the tests. While developing, you can
 run `bin/gemstash` to run Gemstash. You can also run `bin/console` for
 an interactive prompt that will allow you to experiment.
 
+### macOS Dependencies
+
+If you're developing on macOS, you may encounter issues with installing the PostgreSQL and MySQL native gems. To resolve these:
+
+1. Install the required libraries via Homebrew:
+   ```
+   brew install mysql libpq
+   ```
+
+2. Configure Bundler to use the correct paths for building the native extensions:
+   ```
+   # For PostgreSQL
+   bundle config build.pg --with-pg-config=/usr/local/Cellar/libpq/[VERSION]/bin/pg_config
+   # Replace [VERSION] with your installed libpq version (e.g., 17.4_1)
+
+   # For MySQL
+   bundle config build.mysql2 --with-mysql-dir=/usr/local/opt/mysql
+   ```
+
+3. Run `bin/setup` again to complete the installation.
+
+These configurations tell the Ruby gem system where to find the necessary headers and libraries needed to compile the native extensions for these gems.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at


### PR DESCRIPTION
Add a "macOS Dependencies" subsection to the Development section of the README that provides guidance for macOS developers who may encounter issues with PostgreSQL and MySQL gem dependencies.

The instructions include:
- Installing required libraries via Homebrew (mysql, libpq)
- Configuring Bundler with correct paths for native extensions
- Steps to complete the installation process

This should help future developers avoid dependency issues when setting up the project on macOS systems.

# Description:

______________

# Tasks:

This is just an update to the README.md to address potential issues developers running macOS might experience when getting setup to contribute to the project.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
