### PR TITLE
Unskip and fix tests that fail depending on user's local .gemrc file.

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -152,18 +152,27 @@ RSpec.describe "gemstash integration tests" do
       end
 
       it "finds private gems when just the private source is configured", db_transaction: false do
-        skip "this doesn't work because Rubygems sends /specs.4.8.gz instead of /private/specs.4.8.gz"
+        File.write(File.join(env_dir, ".gemrc"), "---\nsources:\n  - #{host}\n")
         env = { "HOME" => env_dir }
+
+        # This way of adjusting sources is required for ruby 3.2 and 3.1 to pass.
         expect(execute("gem", ["source", "-r", "https://rubygems.org/"], env: env)).to exit_success
         expect(execute("gem", ["source", "-a", host], env: env)).to exit_success
+
         expect(execute("gem", ["search", "-ar", "speaker"], env: env)).
           to exit_success.and_output(/speaker \(0.1.0\)/)
       end
 
       it "finds private gems when just the private source is configured with a trailing slash", db_transaction: false do
+        # The presence of `update_sources: true` in the .gemrc file breaks this test, and only this test.
+        # Write a clean .gemrc file to avoid that. (This also makes the test much faster.)
+        File.write(File.join(env_dir, ".gemrc"), "---\nsources:\n  - #{host}/\n")
         env = { "HOME" => env_dir }
+
+        # This way of adjusting sources is required for ruby 3.2 and 3.1 to pass.
         expect(execute("gem", ["source", "-r", "https://rubygems.org/"], env: env)).to exit_success
         expect(execute("gem", ["source", "-a", "#{host}/"], env: env)).to exit_success
+
         expect(execute("gem", ["search", "-ar", "speaker"], env: env)).
           to exit_success.and_output(/speaker \(0.1.0\)/)
       end


### PR DESCRIPTION
# Description:

Without writing .gemrc, the gem source -a and -r don't work correctly. In particular, the presence of update_sources: true in .gemrc breaks one test, while writing the .gemrc fixes a previously skipped test.

______________

# Tasks:

- Fixed local tests for different .gemrc configurations.
- Un-skipped a test that works now with .gemrc written.

I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
