### PR TITLE
Opt out of persisting credentials

### DIFF
--- a/.github/workflows/gemstash-ci.yml
+++ b/.github/workflows/gemstash-ci.yml
@@ -59,6 +59,8 @@ jobs:
       GEMSTASH_SPEC_MEMCACHED_SERVERS: localhost:11211
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
       BUNDLE_WITH: "linting"
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.3


### PR DESCRIPTION

# Description:

`actions/checkout` uses a default value of `true` for `persist-credentials`, which results in credentials being written to the Git config. This change prevents the credentials from being written.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
  - N/A
- [x] I will abide by the [code of conduct](https://github.com/gemstash/gemstash/blob/master/CODE_OF_CONDUCT.md).
