### PR TITLE
Gemstash start readme description about daemonize removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ Simply start the Gemstash server with the `gemstash` command:
 
     $ gemstash start
 
-You may have noticed that the command finished quickly. This is because
-Gemstash will run the server in the background by default. The server
-runs on port 9292.
+The server runs on port 9292.
 
 ### Bundling
 


### PR DESCRIPTION
# Description:

The purpose is to remove the description about the daemonize behavior since is no longer supported and can be misleading for new users.

https://github.com/rubygems/gemstash/pull/381
https://github.com/rubygems/gemstash/pull/378
______________
